### PR TITLE
Issue #3 - better alignment and size for persona images

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -285,17 +285,19 @@ html, body {
 
 .message-row.assistant {
     align-self: flex-start;
+    align-items: flex-start; /* Top-align avatar with bubble, not bottom */
+    gap: 12px;               /* Wider gap to match the larger avatar */
 }
 
 .bubble-avatar {
-    width: 32px;
-    height: 32px;
+    width: 64px;
+    height: 64px;
     border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
     font-weight: 700;
-    font-size: 0.8rem;
+    font-size: 1.5rem;
     color: #fff;
     flex-shrink: 0;
     overflow: hidden;


### PR DESCRIPTION
This PR addresses issue #3 by making the persona avatar images / initial circles larger, and top-aligning them with their chat bubbles instead of bottom-aligning them. Looks much nicer.

Only images in the main chat panel are affected. Avatar images in the side panel are fine as-is and were left alone.