### PR TITLE
Issue #1 - multi-language support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 app/__pycache__/
 app/services/__pycache__/
 app/routers/__pycache__/
-personas.yaml.startrek
+personas.yaml.TNG
+personas.yaml.languages
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ personas:
     avatar_image: null
     reference_audio: null
     reference_audio_transcript: null
+    language: "en"
 ```
 
 #### Persona fields
@@ -84,6 +85,7 @@ personas:
 | `avatar_image` | Path to a local image file (optional) |
 | `reference_audio` | Path to a WAV file for TTS voice cloning (optional) |
 | `reference_audio_transcript` | Path to a TXT file with the audio transcript (required with `reference_audio`) |
+| `language` | Two-letter language code describing the reference audio (defaults to `en`) |
 
 **TTS support**: Both `reference_audio` and `reference_audio_transcript` must be set for a persona to have TTS capability.
 
@@ -119,6 +121,12 @@ TalkWithMe/
 ├── settings.yaml            # Server configuration
 └── requirements.txt
 ```
+
+## Cloning non-English voices
+
+If your reference audio is in English, you're all set.
+
+If your reference audio is in some other language, you must specify the language code in the `language` field for the persona in question. This helps the voice cloner understand the reference audio. This may also prevent the cloned voice from speaking in languages other than the reference audio language, but your mileage may vary.
 
 ## Notes
 

--- a/app/config.py
+++ b/app/config.py
@@ -49,6 +49,7 @@ class Persona(BaseModel):
     avatar_image: Optional[str] = None
     reference_audio: Optional[str] = None
     reference_audio_transcript: Optional[str] = None
+    language: str = "en"
 
     @property
     def tts_capable(self) -> bool:

--- a/app/routers/tts.py
+++ b/app/routers/tts.py
@@ -51,6 +51,7 @@ async def tts_proxy(req: TTSRequest):
         text=req.text,
         prompt_text=transcript,
         audio_base64=audio_b64,
+        language=persona.language,
     )
 
     if not result:

--- a/app/services/tts_client.py
+++ b/app/services/tts_client.py
@@ -34,6 +34,7 @@ async def synthesize(
     text: str,
     prompt_text: str,
     audio_base64: str,
+    language: str = "en",
 ) -> Optional[dict]:
     """Call the TTS server's /synthesize endpoint.
 
@@ -46,6 +47,7 @@ async def synthesize(
         "text": text,
         "prompt_text": prompt_text,
         "audio_base64": audio_base64,
+        "language": language,
         "num_steps": settings.tts.num_steps,
         "guidance_scale": settings.tts.guidance_scale,
         "seed": settings.tts.seed,

--- a/personas.yaml
+++ b/personas.yaml
@@ -7,6 +7,7 @@ personas:
     avatar_image: null
     reference_audio: null
     reference_audio_transcript: null
+    language: "en"
 
   - name: "Luna"
     description: "A philosophical and poetic thinker"
@@ -16,3 +17,4 @@ personas:
     avatar_image: null
     reference_audio: "/home/scorbett/tmp/audio/hermione10s_3.wav"
     reference_audio_transcript: "/home/scorbett/tmp/audio/hermione10s_3.txt"
+    language: "en"

--- a/static/style.css
+++ b/static/style.css
@@ -24,7 +24,7 @@
     --bubble-user: #0f3460;
     --bubble-ai: #16213e;
     --border-color: #2a2a4e;
-    --sidebar-width: 260px;
+    --sidebar-width: 310px;
     --topbar-height: 52px;
     --radius: 12px;
 }


### PR DESCRIPTION
This PR addresses issue #1 by adding support for voice cloning in languages other than English. There's one extra `language` parameter that we have to supply to the TTS server so that it can understand the reference audio. This new property is now exposed in personas config, defaulting to English (as before - this is the default behavior on the TTS server). 

Unrelated, slightly expanded the sidebar so that it can show slightly longer persona descriptions.