### PR TITLE
Issue #2 - implement streaming audio option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 app/__pycache__/
 app/services/__pycache__/
 app/routers/__pycache__/
-personas.yaml.TNG
-personas.yaml.languages
+personas.yaml.*
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ tts:
   guidance_scale: 3.0
   seed: null
   timeout: 60
+  streaming: false
 ```
 
 ### `personas.yaml`
@@ -127,6 +128,17 @@ TalkWithMe/
 If your reference audio is in English, you're all set.
 
 If your reference audio is in some other language, you must specify the language code in the `language` field for the persona in question. This helps the voice cloner understand the reference audio. This may also prevent the cloned voice from speaking in languages other than the reference audio language, but your mileage may vary.
+
+## Streaming TTS responses
+
+If `streaming` is enabled in the TTS configuration, text responses from AI personas will be chunked into sentences using common punctuation, and each sentence will be queued up as a separate TTS request. A separate audio playback queue is used to queue up and play the responses sequentially. 
+
+- Advantage: the initial lag time before playback begins is reduced. The user only has to wait for the first sentence to generate and not the entire text response. As each sentence plays, the next sentence is being processed by the TTS service. Ideally, the lag between sentences is minimal.
+- Disadvantage: sentence length variance can lead to large pauses between sentences. A short sentence followed by a long sentence is the worst case scenario, because the short sentence will process and play very quickly, but the longer sentence will take much longer for the TTS server to process.
+
+If you prefer to hear the persona's response in one clear, contiguous audio playback, and you don't mind the lag time for audio playback to begin, leave streaming mode disabled in configuration (this is the default).
+
+If you want to hear each sentence as soon as it has been synthesized, without having to wait for the ENTIRE response to be synthesized, and you don't mine the occasional pause in between sentences, then enable streaming mode in configuration.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ If `streaming` is enabled in the TTS configuration, text responses from AI perso
 
 If you prefer to hear the persona's response in one clear, contiguous audio playback, and you don't mind the lag time for audio playback to begin, leave streaming mode disabled in configuration (this is the default).
 
-If you want to hear each sentence as soon as it has been synthesized, without having to wait for the ENTIRE response to be synthesized, and you don't mine the occasional pause in between sentences, then enable streaming mode in configuration.
+If you want to hear each sentence as soon as it has been synthesized, without having to wait for the ENTIRE response to be synthesized, and you don't mind the occasional pause in between sentences, then enable streaming mode in configuration.
 
 ## Notes
 

--- a/app/config.py
+++ b/app/config.py
@@ -29,6 +29,7 @@ class TTSConfig(BaseModel):
     guidance_scale: float = 3.0
     seed: Optional[int] = None
     timeout: float = 60.0
+    streaming: bool = False
 
 
 class AppSettings(BaseModel):

--- a/app/models.py
+++ b/app/models.py
@@ -74,6 +74,10 @@ class TTSHealthResponse(BaseModel):
         default=False,
         description="True if the TTS server responded to /health",
     )
+    streaming: bool = Field(
+        default=False,
+        description="True if streaming (sentence-by-sentence) TTS mode is configured",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/app/routers/tts.py
+++ b/app/routers/tts.py
@@ -22,7 +22,11 @@ async def tts_health():
     """Report TTS availability status to the frontend."""
     settings = get_settings()
     available = await check_tts_health() if settings.tts.enabled else False
-    return TTSHealthResponse(enabled=settings.tts.enabled, available=available)
+    return TTSHealthResponse(
+        enabled=settings.tts.enabled,
+        available=available,
+        streaming=settings.tts.streaming,
+    )
 
 
 @router.post("/api/tts")

--- a/devplan.md
+++ b/devplan.md
@@ -154,6 +154,10 @@ or "no volume" or similar symbol with the avatar if the persona cannot speak.
 
 ## TTS Flow
 
+### When not in streaming mode
+
+When the `streaming` config property is set to `false` (or when it is omitted):
+
 1. Frontend receives `done` SSE event for a persona
 2. If TTS enabled and supported for this persona: enqueue `{persona_name, text}` in FIFO audio queue
 3. POST `{text}` to `/api/tts`
@@ -165,6 +169,16 @@ or "no volume" or similar symbol with the avatar if the persona cannot speak.
 5. Returns `{audio_base64, sample_rate}` to frontend
 6. Frontend decodes base64 WAV → Web Audio API → plays audio
 7. Queue processes next item after current audio finishes
+
+### When streaming mode is enabled
+
+When the `streaming` config property is set to `true`:
+
+1. Incoming text streams from the personas are chunked into sentences using a regex to split on common punctuation.
+2. At each sentence boundary, a TTS request for that sentence is queued.
+3. A separate audio playback queue is used to queue up audio responses from the TTS server.
+4. As sentence 1 is being played, sentence 2 can be processing on the TTS server, and so on for sentence 3.
+5. This mode reduces the initial lag time for audio playback to begin, at the expense of possibly causing longer delays between sentences.
 
 ---
 

--- a/settings.yaml
+++ b/settings.yaml
@@ -11,4 +11,4 @@ tts:
   guidance_scale: 1.7
   seed: null
   timeout: 120
-  streaming: true
+  streaming: false

--- a/settings.yaml
+++ b/settings.yaml
@@ -6,8 +6,9 @@ llm:
 
 tts:
   enabled: true
-  base_url: http://saturn-lm:8765
+  base_url: http://saturn-lm:8181
   num_steps: 12
   guidance_scale: 1.7
   seed: null
   timeout: 120
+  streaming: true

--- a/static/app.js
+++ b/static/app.js
@@ -13,16 +13,27 @@ let personas = [];
 let selectedPersona = null;   // The persona selected in the sidebar
 let ttsEnabled = false;        // Whether TTS playback is toggled on
 let ttsAvailable = false;      // Whether the TTS server is reachable
+let ttsStreaming = false;       // Whether streaming (sentence-by-sentence) TTS is enabled
 let isStreaming = false;       // Guard: prevent double-sends during streaming
-
-// FIFO audio queue for TTS playback
-const audioQueue = [];
-let audioCtx = null;
-let isPlayingAudio = false;
 
 // Microphone / STT state
 let mediaRecorder = null;
 let recordedChunks = [];
+
+// Non-streaming: FIFO audio queue (fetch full text, then play)
+const audioQueue = [];
+let audioCtx = null;
+let isPlayingAudio = false;
+
+// Streaming TTS state
+let sentenceBuffer = "";         // Token accumulator for in-progress response
+let currentStreamingPersona = null;
+
+// Streaming: decoupled fetch queue and decoded-buffer playback queue
+const ttsRequestQueue = [];      // [{personaName, text}] waiting to be fetched
+const audioBufferQueue = [];     // AudioBuffers decoded and ready to play
+let isFetchingTTS = false;
+let isPlayingAudioBuffer = false;
 
 /* ==========================================================================
    DOM references
@@ -75,11 +86,13 @@ async function checkTTSHealth() {
         const resp = await fetch("/api/tts/health");
         const data = await resp.json();
         ttsAvailable = data.available;
+        ttsStreaming = data.streaming || false;
         ttsEnabled = data.available; // Default on if server is available
         updateTTSToggleUI();
     } catch (err) {
         console.warn("TTS health check failed:", err);
         ttsAvailable = false;
+        ttsStreaming = false;
         ttsEnabled = false;
         updateTTSToggleUI();
     }
@@ -282,6 +295,12 @@ function handleSSEEvent(event, assistantRow) {
                 selectedPersona = event.persona;
                 highlightSelectedPersona();
             }
+
+            // Streaming TTS: track persona and reset sentence accumulator
+            if (ttsStreaming) {
+                currentStreamingPersona = event.persona;
+                sentenceBuffer = "";
+            }
             break;
         }
         case "token": {
@@ -290,14 +309,32 @@ function handleSSEEvent(event, assistantRow) {
                 bubble.textContent += event.token;
                 scrollToBottom();
             }
+
+            // Streaming TTS: accumulate tokens and queue complete sentences immediately
+            if (ttsEnabled && ttsStreaming && currentStreamingPersona) {
+                const persona = personas.find(p => p.name === currentStreamingPersona);
+                if (persona && persona.tts_capable) {
+                    accumulateForTTS(event.token, currentStreamingPersona);
+                }
+            }
             break;
         }
         case "done": {
-            // Streaming complete — enqueue TTS if enabled
             if (ttsEnabled && event.text) {
                 const persona = personas.find(p => p.name === event.persona);
                 if (persona && persona.tts_capable) {
-                    enqueueTTS(event.persona, event.text);
+                    if (ttsStreaming) {
+                        // Flush any remaining partial sentence from the buffer
+                        const remaining = sentenceBuffer.trim();
+                        if (remaining) {
+                            enqueueStreamingTTS(event.persona, remaining);
+                        }
+                        sentenceBuffer = "";
+                        currentStreamingPersona = null;
+                    } else {
+                        // Non-streaming: enqueue full text at once (original behavior)
+                        enqueueTTS(event.persona, event.text);
+                    }
                 }
             }
             break;
@@ -430,6 +467,10 @@ function toggleTTS() {
     updateTTSToggleUI();
 }
 
+// ---------------------------------------------------------------------------
+// Non-streaming TTS (original behavior: enqueue full text after LLM finishes)
+// ---------------------------------------------------------------------------
+
 function enqueueTTS(personaName, text) {
     audioQueue.push({ personaName, text });
     processAudioQueue();
@@ -449,10 +490,98 @@ async function processAudioQueue() {
         console.warn("TTS playback error:", err);
     } finally {
         isPlayingAudio = false;
-        // Process next item in queue
         setTimeout(() => processAudioQueue(), 100);
     }
 }
+
+// ---------------------------------------------------------------------------
+// Streaming TTS (sentence-by-sentence: fetch and play are pipelined)
+// ---------------------------------------------------------------------------
+
+/**
+ * Split accumulated text into complete sentences (ending with . ! ?)
+ * Returns the sentences found and any remaining fragment without a terminal.
+ */
+function extractSentences(text) {
+    const sentences = [];
+    const regex = /[^.!?]*[.!?]+/g;
+    let lastIndex = 0;
+    let match;
+    while ((match = regex.exec(text)) !== null) {
+        const s = match[0].trim();
+        if (s) sentences.push(s);
+        lastIndex = regex.lastIndex;
+    }
+    return { sentences, remaining: text.slice(lastIndex) };
+}
+
+/**
+ * Append a token to the sentence buffer and queue any newly complete sentences.
+ */
+function accumulateForTTS(token, personaName) {
+    sentenceBuffer += token;
+    const { sentences, remaining } = extractSentences(sentenceBuffer);
+    sentenceBuffer = remaining;
+    for (const sentence of sentences) {
+        enqueueStreamingTTS(personaName, sentence);
+    }
+}
+
+/** Push a sentence into the fetch queue and kick off the fetch pipeline. */
+function enqueueStreamingTTS(personaName, text) {
+    ttsRequestQueue.push({ personaName, text });
+    processTTSRequests();
+}
+
+/**
+ * Fetch TTS for queued sentences serially (to preserve order).
+ * Runs concurrently with audio playback so the next sentence's audio
+ * is ready by the time the current one finishes playing.
+ */
+async function processTTSRequests() {
+    if (isFetchingTTS || ttsRequestQueue.length === 0) return;
+    isFetchingTTS = true;
+
+    const item = ttsRequestQueue.shift();
+    try {
+        const audioBuffer = await fetchTTS(item.personaName, item.text);
+        if (audioBuffer) {
+            audioBufferQueue.push(audioBuffer);
+            processAudioBufferQueue();
+        }
+    } catch (err) {
+        console.warn("TTS streaming fetch error:", err);
+    } finally {
+        isFetchingTTS = false;
+        // Immediately fetch the next sentence if one is waiting
+        setTimeout(() => processTTSRequests(), 0);
+    }
+}
+
+/**
+ * Play decoded audio buffers in order, with a small gap between sentences.
+ * Runs independently of the fetch pipeline so playback starts as soon as
+ * the first buffer is ready.
+ */
+async function processAudioBufferQueue() {
+    if (isPlayingAudioBuffer || audioBufferQueue.length === 0) return;
+    isPlayingAudioBuffer = true;
+
+    const buffer = audioBufferQueue.shift();
+    try {
+        await playAudio(buffer);
+        await new Promise(resolve => setTimeout(resolve, 80)); // brief inter-sentence gap
+    } catch (err) {
+        console.warn("Audio buffer playback error:", err);
+    } finally {
+        isPlayingAudioBuffer = false;
+        processAudioBufferQueue();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared TTS helpers
+// ---------------------------------------------------------------------------
 
 async function fetchTTS(personaName, text) {
     const resp = await fetch("/api/tts", {


### PR DESCRIPTION
This PR addresses issue #2 by adding a new "streaming" option for TTS audio output:

- if enabled, text responses will be chunked into sentences using common punctuation, and queued up as separate TTS requests.
- if disabled, the ENTIRE text response will be sent up as a single TTS request.

By default, the new option is disabled, to match the old behavior.

Updated the dev plan and the README to reflect this new feature. The README in particular points out the pros and cons of enabling this new option.