### PR TITLE
Issue #21 - change STT to OpenAI-compatible API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,13 @@ As seen on YouTube!: https://www.youtube.com/watch?v=1VPydYNt4R8
 
 - Python 3.10+
 - A locally running llama.cpp server with OpenAI-compatible API (e.g., `--api` flag)
-- (Optional) A local TTS/STT REST server with `/synthesize`, `/parse`, and `/health` endpoints.
+- (Optional) A local TTS REST server with `/synthesize` and `/health` endpoints.
    You can use my [server.py](https://github.com/scorbo2/ai-playground/blob/master/dots.tts/server.py)
    in front of a [dots.tts](https://github.com/studio-dots-ai/dots.tts) server (that's what I use.)
+- (Optional) An OpenAI-compatible STT server that exposes a `/v1/audio/transcriptions` endpoint
+   accepting multipart form uploads. The `stt.base_url` in `settings.yaml` should point to the
+   server's root (e.g., `http://localhost:8181`), and the app will POST to
+   `{base_url}/v1/audio/transcriptions`.
 
 ## Quick Start
 
@@ -60,9 +64,15 @@ tts:
 
 stt:
   enabled: true
-  base_url: http://localhost:5501
+  base_url: http://localhost:8181
   timeout: 30
 ```
+
+The STT `base_url` should point to an OpenAI-compatible server. The app sends audio
+as a multipart form POST to `{base_url}/v1/audio/transcriptions` with
+`response_format=json`. The server must return a JSON object containing at least a
+`text` field. Optional response fields `language` (defaults to `"en"`) and
+`language_probability` are also supported.
 
 Note that TTS and STT are both optional! You can mark them as disabled
 and/or leave the base_url field blank or null. The only mandatory
@@ -172,7 +182,7 @@ If you want to hear each sentence as soon as it has been synthesized, without ha
 ## Notes
 
 - The TTS server is optional. If unreachable, TTS is silently disabled.
-- The STT server is optional. If unreachable, STT is silently disabled.
+- The STT server is optional. If unreachable or misconfigured, STT is gracefully disabled with an error message.
 - Single-user design: only one active chat session exists at a time.
 - "New Chat" clears all conversation history.
 
@@ -191,7 +201,8 @@ If you want to hear each sentence as soon as it has been synthesized, without ha
   - Color theme chooser with persistence (#12)
 - **TODO** v3.0
   - In-app persona editor: create, edit, clone, and delete personas from the browser UI (#11)
-  - Split TTS and STT into separate features with separate configuration
+  - Migrate STT to OpenAI-compatible `/v1/audio/transcriptions` endpoint (#21)
+  - Split TTS and STT into separate features with separate configuration (#19)
 
 ## License
 

--- a/app/models.py
+++ b/app/models.py
@@ -52,6 +52,10 @@ class TTSRequest(BaseModel):
 class STTRequest(BaseModel):
     """Proxy request to the STT server."""
     audio_base64: str = Field(..., min_length=1, description="Base64-encoded audio to transcribe")
+    audio_mime_type: Optional[str] = Field(
+        default="audio/webm",
+        description="MIME type of the recorded audio (e.g. audio/webm, audio/ogg)",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -94,9 +98,10 @@ class TTSResponse(BaseModel):
 
 
 class STTResponse(BaseModel):
-    """Transcribed text from the STT server."""
+    """Transcribed text from an OpenAI-compatible STT server."""
     text: str
-    language: Optional[str] = None
+    language: str = "en"
+    language_probability: Optional[float] = None
 
 
 class TTSHealthResponse(BaseModel):

--- a/app/routers/stt.py
+++ b/app/routers/stt.py
@@ -46,11 +46,11 @@ async def stt_proxy(req: STTRequest):
         return JSONResponse(status_code=400, content={"detail": "Invalid audio data"})
 
     try:
-        result = await transcribe_audio(audio_bytes, mime_type=req.audio_mime_type)
+        mime_type = req.audio_mime_type or "audio/webm"
+        result = await transcribe_audio(audio_bytes, mime_type=mime_type)
     except Exception:
         return JSONResponse(status_code=502, content={"detail": "Unable to process STT data"})
 
-    if not result or not result.get("text"):
+    if not result:
         return JSONResponse(status_code=502, content={"detail": "Unable to process STT data"})
-
     return result

--- a/app/routers/stt.py
+++ b/app/routers/stt.py
@@ -1,9 +1,10 @@
-"""STT router — proxy to the local STT server.
+"""STT router — proxy to an OpenAI-compatible STT server.
 
 Handles speech-to-text transcription requests. The STT server is optional;
 the app degrades gracefully if it's unavailable or disabled.
 """
 
+import base64
 import logging
 
 from fastapi import APIRouter
@@ -11,7 +12,7 @@ from fastapi.responses import JSONResponse
 
 from app.config import get_settings
 from app.models import STTRequest, STTResponse, STTHealthResponse
-from app.services.stt_client import check_stt_health, parse_audio
+from app.services.stt_client import check_stt_health, transcribe_audio
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["stt"])
@@ -30,20 +31,26 @@ async def stt_health():
 
 @router.post("/api/stt", response_model=STTResponse)
 async def stt_proxy(req: STTRequest):
-    """Proxy a speech-to-text request to the STT server's /parse endpoint.
+    """Proxy a speech-to-text request to the STT server.
 
-    Accepts base64-encoded audio and returns the transcribed text.
+    Accepts base64-encoded audio from the frontend, decodes it, and forwards
+    as multipart form data to the OpenAI-compatible /v1/audio/transcriptions endpoint.
     """
     settings = get_settings()
     if not settings.stt.is_active:
         return JSONResponse(status_code=503, content={"detail": "STT is disabled in settings"})
 
     try:
-        result = await parse_audio(req.audio_base64)
+        audio_bytes = base64.b64decode(req.audio_base64)
     except Exception:
-        return JSONResponse(status_code=502, content={"detail": "STT server unavailable or returned an error"})
+        return JSONResponse(status_code=400, content={"detail": "Invalid audio data"})
 
-    if not result or "text" not in result:
-        return JSONResponse(status_code=502, content={"detail": "STT server returned no text"})
+    try:
+        result = await transcribe_audio(audio_bytes, mime_type=req.audio_mime_type)
+    except Exception:
+        return JSONResponse(status_code=502, content={"detail": "Unable to process STT data"})
+
+    if not result or not result.get("text"):
+        return JSONResponse(status_code=502, content={"detail": "Unable to process STT data"})
 
     return result

--- a/app/services/stt_client.py
+++ b/app/services/stt_client.py
@@ -1,10 +1,12 @@
-"""STT client — talks to a local REST server's /parse endpoint.
+"""STT client — talks to an OpenAI-compatible STT server.
 
+Sends raw audio as a multipart form POST to /v1/audio/transcriptions.
 The STT server is optional. If it's down or misconfigured, the app logs
 a warning and returns None to the caller.
 """
 
 import logging
+import mimetypes
 from typing import Optional
 
 import httpx
@@ -12,6 +14,15 @@ import httpx
 from app.config import get_settings
 
 logger = logging.getLogger(__name__)
+
+
+def _mime_to_extension(mime_type: str) -> str:
+    """Derive a file extension from a MIME type, falling back to 'bin'."""
+    ext = mimetypes.guess_extension(mime_type)
+    if ext and ext.startswith("."):
+        return ext[1:]  # strip leading dot
+    # Fallback: use the subtype (e.g. "audio/webm" -> "webm")
+    return mime_type.split("/")[-1]
 
 
 async def check_stt_health() -> bool:
@@ -31,24 +42,50 @@ async def check_stt_health() -> bool:
         return False
 
 
-async def parse_audio(audio_base64: str) -> Optional[dict]:
-    """Call the STT server's /parse endpoint.
+async def transcribe_audio(audio_bytes: bytes, mime_type: str = "audio/webm") -> Optional[dict]:
+    """Call the STT server's /v1/audio/transcriptions endpoint.
 
-    Returns dict with {"text": str, "language": str} or None on failure.
+    Sends raw audio as multipart form data with response_format=json.
+    Returns dict with keys: text, language, language_probability.
+    Returns None on any failure.
     """
     settings = get_settings()
     if not settings.stt.is_active:
-        logger.warning("STT parse skipped: feature not active (no base_url or disabled)")
+        logger.warning("STT transcribe skipped: feature not active (no base_url or disabled)")
         return None
-    url = f"{settings.stt.base_url}/parse"
+    if not audio_bytes:
+        logger.warning("STT transcribe skipped: no audio data provided")
+        return None
+    url = f"{settings.stt.base_url}/v1/audio/transcriptions"
 
-    payload = {"audio_base64": audio_base64}
+    # Derive a sensible filename from the MIME type so the STT server
+    # can identify the format. E.g. "audio/ogg" -> "audio.ogg"
+    ext = _mime_to_extension(mime_type)
+    files = {
+        "file": (f"audio.{ext}", audio_bytes, mime_type),
+    }
+    data = {
+        "response_format": "json",
+    }
 
     try:
         async with httpx.AsyncClient(timeout=settings.stt.timeout) as client:
-            resp = await client.post(url, json=payload)
+            resp = await client.post(url, files=files, data=data)
             resp.raise_for_status()
-            return resp.json()
+            json_response = resp.json()
+            return {
+                "text": json_response.get("text", ""),
+                # "language" is optional in the response; default to "en" if absent
+                "language": json_response.get("language", "en"),
+                # "language_probability" is optional; None if the server doesn't provide it
+                "language_probability": json_response.get("language_probability"),
+            }
+    except httpx.ConnectError as exc:
+        logger.error("STT connect error (server unreachable at %s): %s", url, exc)
+    except httpx.TimeoutException as exc:
+        logger.error("STT timeout after %.0fs: %s", settings.stt.timeout, exc)
+    except httpx.HTTPStatusError as exc:
+        logger.error("STT HTTP %d from %s: %s", exc.response.status_code, url, exc)
     except Exception as exc:
-        logger.warning("STT parse failed: %s", exc)
-        return None
+        logger.warning("STT transcribe failed: %s", exc)
+    return None

--- a/app/services/stt_client.py
+++ b/app/services/stt_client.py
@@ -64,6 +64,7 @@ async def transcribe_audio(audio_bytes: bytes, mime_type: str = "audio/webm") ->
 
     # Derive a sensible filename from the MIME type so the STT server
     # can identify the format. E.g. "audio/ogg" -> "audio.ogg"
+    mime_type = (mime_type or "audio/webm").split(";", 1)[0].strip() or "audio/webm"
     ext = _mime_to_extension(mime_type)
     files = {
         "file": (f"audio.{ext}", audio_bytes, mime_type),

--- a/app/services/stt_client.py
+++ b/app/services/stt_client.py
@@ -18,11 +18,15 @@ logger = logging.getLogger(__name__)
 
 def _mime_to_extension(mime_type: str) -> str:
     """Derive a file extension from a MIME type, falling back to 'bin'."""
-    ext = mimetypes.guess_extension(mime_type)
+    base = (mime_type or "").split(";", 1)[0].strip()
+    if "/" not in base:
+        return "bin"
+    ext = mimetypes.guess_extension(base)
     if ext and ext.startswith("."):
         return ext[1:]  # strip leading dot
     # Fallback: use the subtype (e.g. "audio/webm" -> "webm")
-    return mime_type.split("/")[-1]
+    subtype = base.split("/", 1)[1]
+    return subtype or "bin"
 
 
 async def check_stt_health() -> bool:

--- a/app/services/stt_client.py
+++ b/app/services/stt_client.py
@@ -78,10 +78,11 @@ async def transcribe_audio(audio_bytes: bytes, mime_type: str = "audio/webm") ->
             resp = await client.post(url, files=files, data=data)
             resp.raise_for_status()
             json_response = resp.json()
+            text = json_response.get("text") or "No response received from STT server"
             return {
-                "text": json_response.get("text", ""),
+                "text": text,
                 # "language" is optional in the response; default to "en" if absent
-                "language": json_response.get("language", "en"),
+                "language": json_response.get("language") or "en",
                 # "language_probability" is optional; None if the server doesn't provide it
                 "language_probability": json_response.get("language_probability"),
             }

--- a/static/app.js
+++ b/static/app.js
@@ -681,8 +681,7 @@ async function toggleMicrophone() {
     mediaRecorder = new MediaRecorder(stream);
     // Capture the actual MIME type the browser chose. Different browsers/platforms
     // may produce webm, ogg, mp4, or other containers.
-    const audioMimeType = mediaRecorder.mimeType;
-
+    const audioMimeType = mediaRecorder.mimeType || "audio/webm";
     mediaRecorder.ondataavailable = (e) => {
         if (e.data.size > 0) recordedChunks.push(e.data);
     };

--- a/static/app.js
+++ b/static/app.js
@@ -679,6 +679,9 @@ async function toggleMicrophone() {
 
     recordedChunks = [];
     mediaRecorder = new MediaRecorder(stream);
+    // Capture the actual MIME type the browser chose. Different browsers/platforms
+    // may produce webm, ogg, mp4, or other containers.
+    const audioMimeType = mediaRecorder.mimeType;
 
     mediaRecorder.ondataavailable = (e) => {
         if (e.data.size > 0) recordedChunks.push(e.data);
@@ -690,7 +693,7 @@ async function toggleMicrophone() {
         micBtn.classList.remove("recording");
         micBtn.disabled = true;
 
-        const blob = new Blob(recordedChunks, { type: "audio/webm" });
+        const blob = new Blob(recordedChunks, { type: audioMimeType });
 
         const audio_base64 = await new Promise((resolve, reject) => {
             const reader = new FileReader();
@@ -706,12 +709,12 @@ async function toggleMicrophone() {
             const resp = await fetch("/api/stt", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ audio_base64 }),
+                body: JSON.stringify({ audio_base64, audio_mime_type: audioMimeType }),
             });
 
             if (!resp.ok) {
                 console.error("STT request failed:", resp.status);
-                appendErrorBubble("Speech recognition failed. Microphone disabled.");
+                appendErrorBubble("Unable to process STT data.");
                 sttFailed = true;
                 return;
             }
@@ -726,7 +729,7 @@ async function toggleMicrophone() {
             }
         } catch (err) {
             console.error("STT error:", err);
-            appendErrorBubble("Speech recognition failed. Microphone disabled.");
+            appendErrorBubble("Unable to process STT data.");
             sttFailed = true;
         } finally {
             if (!sttFailed) micBtn.disabled = false;


### PR DESCRIPTION
This PR addresses issue #21 by ditching the old, custom `/parse` endpoint for STT parsing, and switching to an OpenAI-compatibile `/v1/audio/transcriptions` endpoint instead. Users can now point directly to a service like `whisper-fastapi` for STT transcription instead of using the old custom `server.py` shim. As a bonus, we are now receiving a new `language_probability` field in the response. This is currently unused, but we will make use of it in a future ticket.

Updated the README to describe this change. This will be a breaking change from previous versions, but the improved interoperability is worth it.