### PR TITLE
Issue #23 - add UI for server settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Open `http://localhost:8000` in your browser.
 
 ### `settings.yaml`
 
+(Note: as of v3, you can also edit these settings in-application via the "settings" control in the top right of the page).
+
 Configure your LLM, TTS, and STT server endpoints:
 
 ```yaml
@@ -203,6 +205,7 @@ If you want to hear each sentence as soon as it has been synthesized, without ha
   - In-app persona editor: create, edit, clone, and delete personas from the browser UI (#11)
   - Migrate STT to OpenAI-compatible `/v1/audio/transcriptions` endpoint (#21)
   - Split TTS and STT into separate features with separate configuration (#19)
+  - Add UI for server connection settings (#23)
 
 ## License
 

--- a/app/config.py
+++ b/app/config.py
@@ -162,6 +162,20 @@ def save_personas(config: PersonasConfig, path: Optional[Path] = None) -> None:
     _personas_cache = config
 
 
+def save_settings(config: AppSettings, path: Optional[Path] = None) -> None:
+    """Serialize AppSettings back to settings.yaml and update the in-memory cache."""
+    global _settings_cache
+    target = path or _PROJECT_ROOT / "settings.yaml"
+    raw = {
+        "llm": config.llm.model_dump(exclude_none=False),
+        "tts": config.tts.model_dump(exclude_none=False),
+        "stt": config.stt.model_dump(exclude_none=False),
+    }
+    with open(target, "w") as f:
+        yaml.dump(raw, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+    _settings_cache = config
+
+
 def reload_all():
     """Force-reload both config files. Useful for dev hot-reload."""
     global _settings_cache, _personas_cache

--- a/app/main.py
+++ b/app/main.py
@@ -14,7 +14,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from app import config as app_config
-from app.routers import chat, personas, session as session_router, stt, tts
+from app.routers import chat, personas, session as session_router, settings, stt, tts
 from app.session import session
 
 logger = logging.getLogger(__name__)
@@ -63,6 +63,7 @@ app.include_router(session_router.router)
 app.include_router(chat.router)
 app.include_router(tts.router)
 app.include_router(stt.router)
+app.include_router(settings.router)
 
 # Jinja2 templates
 templates = Jinja2Templates(directory=str(Path(__file__).resolve().parent.parent / "templates"))

--- a/app/models.py
+++ b/app/models.py
@@ -127,6 +127,76 @@ class STTHealthResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Settings models
+# ---------------------------------------------------------------------------
+
+class LLMSettingsRequest(BaseModel):
+    """LLM configuration from the settings editor."""
+    base_url: str = Field(..., min_length=1)
+    model: str = Field(..., min_length=1)
+    max_tokens: int = Field(..., ge=1)
+    temperature: float = Field(..., ge=0.0, le=1.0)
+
+
+class TTSSettingsRequest(BaseModel):
+    """TTS configuration from the settings editor."""
+    enabled: bool = True
+    base_url: str = Field(default="", min_length=0)
+    num_steps: int = Field(..., ge=4, le=20)
+    guidance_scale: float = Field(..., ge=1.0, le=2.0)
+    seed: int = Field(default=0, description="0 means null (no seed)")
+    timeout: float = Field(..., ge=5, le=300)
+    streaming: bool = False
+
+
+class STTSettingsRequest(BaseModel):
+    """STT configuration from the settings editor."""
+    enabled: bool = True
+    base_url: str = Field(default="", min_length=0)
+    timeout: float = Field(..., ge=5, le=300)
+
+
+class SettingsUpdateRequest(BaseModel):
+    """Full settings payload from the frontend settings editor."""
+    llm: LLMSettingsRequest
+    tts: TTSSettingsRequest
+    stt: STTSettingsRequest
+
+
+class LLMSettingsResponse(BaseModel):
+    """LLM configuration for the frontend."""
+    base_url: str
+    model: str
+    max_tokens: int
+    temperature: float
+
+
+class TTSSettingsResponse(BaseModel):
+    """TTS configuration for the frontend."""
+    enabled: bool
+    base_url: Optional[str] = None
+    num_steps: int
+    guidance_scale: float
+    seed: Optional[int] = None
+    timeout: float
+    streaming: bool
+
+
+class STTSettingsResponse(BaseModel):
+    """STT configuration for the frontend."""
+    enabled: bool
+    base_url: Optional[str] = None
+    timeout: float
+
+
+class SettingsResponse(BaseModel):
+    """Full settings payload returned to the frontend."""
+    llm: LLMSettingsResponse
+    tts: TTSSettingsResponse
+    stt: STTSettingsResponse
+
+
+# ---------------------------------------------------------------------------
 # Internal models (not exposed over the API)
 # ---------------------------------------------------------------------------
 

--- a/app/routers/settings.py
+++ b/app/routers/settings.py
@@ -1,0 +1,92 @@
+"""Settings router — read and update application settings from settings.yaml."""
+
+import logging
+
+from fastapi import APIRouter
+
+from app import config as app_config
+from app.config import AppSettings, LLMSettings, STTConfig, TTSConfig
+from app.models import (
+    LLMSettingsResponse,
+    SettingsResponse,
+    SettingsUpdateRequest,
+    STTSettingsResponse,
+    TTSSettingsResponse,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/settings", tags=["settings"])
+
+
+def _to_response(cfg: AppSettings) -> SettingsResponse:
+    """Convert internal AppSettings to the API response model."""
+    return SettingsResponse(
+        llm=LLMSettingsResponse(
+            base_url=cfg.llm.base_url,
+            model=cfg.llm.model,
+            max_tokens=cfg.llm.max_tokens,
+            temperature=cfg.llm.temperature,
+        ),
+        tts=TTSSettingsResponse(
+            enabled=cfg.tts.enabled,
+            base_url=cfg.tts.base_url,
+            num_steps=cfg.tts.num_steps,
+            guidance_scale=cfg.tts.guidance_scale,
+            seed=cfg.tts.seed,
+            timeout=cfg.tts.timeout,
+            streaming=cfg.tts.streaming,
+        ),
+        stt=STTSettingsResponse(
+            enabled=cfg.stt.enabled,
+            base_url=cfg.stt.base_url,
+            timeout=cfg.stt.timeout,
+        ),
+    )
+
+
+@router.get("", response_model=SettingsResponse)
+def get_settings():
+    """Return current application settings."""
+    return _to_response(app_config.get_settings())
+
+
+@router.put("", response_model=SettingsResponse)
+def update_settings(req: SettingsUpdateRequest):
+    """Update application settings and persist to settings.yaml.
+
+    The frontend sends seed=0 to mean "no seed" (null). We normalize that
+    here so the YAML and in-memory cache stay consistent.
+    """
+    # Normalize: blank base_url strings -> None, seed 0 -> None
+    tts_base = req.tts.base_url if req.tts.base_url.strip() else None
+    stt_base = req.stt.base_url if req.stt.base_url.strip() else None
+    tts_seed = None if req.tts.seed == 0 else req.tts.seed
+
+    updated = AppSettings(
+        llm=LLMSettings(
+            base_url=req.llm.base_url,
+            model=req.llm.model,
+            max_tokens=req.llm.max_tokens,
+            temperature=req.llm.temperature,
+        ),
+        tts=TTSConfig(
+            enabled=req.tts.enabled,
+            base_url=tts_base,
+            num_steps=req.tts.num_steps,
+            guidance_scale=req.tts.guidance_scale,
+            seed=tts_seed,
+            timeout=req.tts.timeout,
+            streaming=req.tts.streaming,
+        ),
+        stt=STTConfig(
+            enabled=req.stt.enabled,
+            base_url=stt_base,
+            timeout=req.stt.timeout,
+        ),
+    )
+
+    app_config.save_settings(updated)
+    logger.info("Settings updated: llm=%s, tts_active=%s, stt_active=%s",
+                updated.llm.base_url, updated.tts.is_active, updated.stt.is_active)
+
+    return _to_response(updated)

--- a/static/app.js
+++ b/static/app.js
@@ -1118,10 +1118,15 @@ sfSttEnabled.addEventListener("change", () => {
     updateSttFieldsState();
 });
 
-function openSettings() {
+async function openSettings() {
     settingsOverlay.classList.remove("hidden");
     settingsError.classList.add("hidden");
-    loadSettingsIntoForm();
+
+    const saveBtn = document.getElementById("settings-btn-save");
+    saveBtn.disabled = true;
+
+    const ok = await loadSettingsIntoForm();
+    saveBtn.disabled = !ok;
 }
 
 function closeSettings() {
@@ -1133,12 +1138,16 @@ async function loadSettingsIntoForm() {
         const resp = await fetch("/api/settings");
         if (!resp.ok) {
             console.error("Failed to load settings:", resp.status);
-            return;
+            showSettingsError(`Failed to load settings (HTTP ${resp.status}).`);
+            return false;
         }
         const data = await resp.json();
         populateSettingsForm(data);
+        return true;
     } catch (err) {
         console.error("Failed to load settings:", err);
+        showSettingsError("Failed to load settings. Is the server running?");
+        return false;
     }
 }
 

--- a/static/app.js
+++ b/static/app.js
@@ -14,6 +14,7 @@ let selectedPersona = null;   // The persona selected in the sidebar
 let ttsEnabled = false;        // Whether TTS playback is toggled on
 let ttsAvailable = false;      // Whether the TTS server is reachable
 let ttsStreaming = false;       // Whether streaming (sentence-by-sentence) TTS is enabled
+let sttAvailable = false;      // Whether the STT server is reachable
 let isStreaming = false;       // Guard: prevent double-sends during streaming
 
 // Microphone / STT state
@@ -59,6 +60,7 @@ async function init() {
     initTheme();
     await loadPersonas();
     await checkTTSHealth();
+    await checkSTTHealth();
     setupEventListeners();
     showEmptyState();
 }
@@ -99,6 +101,23 @@ async function checkTTSHealth() {
         ttsEnabled = false;
         updateTTSToggleUI();
     }
+}
+
+async function checkSTTHealth() {
+    try {
+        const resp = await fetch("/api/stt/health");
+        const data = await resp.json();
+        sttAvailable = data.available;
+        updateMicButtonUI();
+    } catch (err) {
+        console.warn("STT health check failed:", err);
+        sttAvailable = false;
+        updateMicButtonUI();
+    }
+}
+
+function updateMicButtonUI() {
+    micBtn.disabled = !sttAvailable;
 }
 
 function setupEventListeners() {
@@ -1038,7 +1057,7 @@ function showPersonaFormError(msg) {
 
 function escapeHtml(str) {
   if (typeof str !== 'string') return str;
-  
+
   return str.replace(/[&<>"']/g, match => {
     return {
       '&': '&amp;',
@@ -1048,5 +1067,222 @@ function escapeHtml(str) {
       "'": '&#39;'
     }[match];
   });
+}
+
+/* ==========================================================================
+   Settings Modal
+   ========================================================================== */
+
+const settingsOverlay   = document.getElementById("settings-overlay");
+const settingsForm      = document.getElementById("settings-form");
+const settingsError     = document.getElementById("settings-error");
+
+// LLM fields
+const sfLlmBaseUrl      = document.getElementById("sf-llm-base-url");
+const sfLlmModel        = document.getElementById("sf-llm-model");
+const sfLlmMaxTokens    = document.getElementById("sf-llm-max-tokens");
+const sfLlmTemperature  = document.getElementById("sf-llm-temperature");
+
+// TTS fields
+const sfTtsEnabled      = document.getElementById("sf-tts-enabled");
+const sfTtsFields       = document.getElementById("sf-tts-fields");
+const sfTtsBaseUrl      = document.getElementById("sf-tts-base-url");
+const sfTtsNumSteps     = document.getElementById("sf-tts-num-steps");
+const sfTtsGuidanceScale = document.getElementById("sf-tts-guidance-scale");
+const sfTtsSeed         = document.getElementById("sf-tts-seed");
+const sfTtsTimeout      = document.getElementById("sf-tts-timeout");
+const sfTtsStreaming    = document.getElementById("sf-tts-streaming");
+
+// STT fields
+const sfSttEnabled      = document.getElementById("sf-stt-enabled");
+const sfSttFields       = document.getElementById("sf-stt-fields");
+const sfSttBaseUrl      = document.getElementById("sf-stt-base-url");
+const sfSttTimeout      = document.getElementById("sf-stt-timeout");
+
+// Event listeners
+document.getElementById("btn-settings").addEventListener("click", openSettings);
+document.getElementById("settings-btn-close").addEventListener("click", closeSettings);
+document.getElementById("settings-btn-cancel").addEventListener("click", closeSettings);
+settingsForm.addEventListener("submit", submitSettings);
+
+// Close on backdrop click
+settingsOverlay.addEventListener("click", (e) => {
+    if (e.target === settingsOverlay) closeSettings();
+});
+
+// Toggle TTS/STT fields visibility on checkbox change
+sfTtsEnabled.addEventListener("change", () => {
+    updateTtsFieldsState();
+});
+sfSttEnabled.addEventListener("change", () => {
+    updateSttFieldsState();
+});
+
+function openSettings() {
+    settingsOverlay.classList.remove("hidden");
+    settingsError.classList.add("hidden");
+    loadSettingsIntoForm();
+}
+
+function closeSettings() {
+    settingsOverlay.classList.add("hidden");
+}
+
+async function loadSettingsIntoForm() {
+    try {
+        const resp = await fetch("/api/settings");
+        if (!resp.ok) {
+            console.error("Failed to load settings:", resp.status);
+            return;
+        }
+        const data = await resp.json();
+        populateSettingsForm(data);
+    } catch (err) {
+        console.error("Failed to load settings:", err);
+    }
+}
+
+function populateSettingsForm(data) {
+    // LLM (always populated)
+    sfLlmBaseUrl.value = data.llm.base_url || "";
+    sfLlmModel.value = data.llm.model || "";
+    sfLlmMaxTokens.value = data.llm.max_tokens || 1024;
+    sfLlmTemperature.value = data.llm.temperature ?? 0.8;
+
+    // TTS
+    sfTtsEnabled.checked = data.tts.enabled;
+    sfTtsBaseUrl.value = data.tts.base_url || "";
+    sfTtsNumSteps.value = data.tts.num_steps ?? 12;
+    sfTtsGuidanceScale.value = data.tts.guidance_scale ?? 1.5;
+    // seed: null from API -> 0 in form (0 means "no seed")
+    sfTtsSeed.value = data.tts.seed ?? 0;
+    sfTtsTimeout.value = data.tts.timeout ?? 120;
+    sfTtsStreaming.checked = data.tts.streaming || false;
+    updateTtsFieldsState();
+
+    // STT
+    sfSttEnabled.checked = data.stt.enabled;
+    sfSttBaseUrl.value = data.stt.base_url || "";
+    sfSttTimeout.value = data.stt.timeout ?? 30;
+    updateSttFieldsState();
+}
+
+function updateTtsFieldsState() {
+    if (sfTtsEnabled.checked) {
+        sfTtsFields.classList.remove("disabled");
+    } else {
+        sfTtsFields.classList.add("disabled");
+    }
+}
+
+function updateSttFieldsState() {
+    if (sfSttEnabled.checked) {
+        sfSttFields.classList.remove("disabled");
+    } else {
+        sfSttFields.classList.add("disabled");
+    }
+}
+
+function showSettingsError(msg) {
+    settingsError.textContent = msg;
+    settingsError.classList.remove("hidden");
+}
+
+function collectSettingsFromForm() {
+    return {
+        llm: {
+            base_url: sfLlmBaseUrl.value.trim(),
+            model: sfLlmModel.value.trim(),
+            max_tokens: parseInt(sfLlmMaxTokens.value, 10),
+            temperature: parseFloat(sfLlmTemperature.value),
+        },
+        tts: {
+            enabled: sfTtsEnabled.checked,
+            base_url: sfTtsBaseUrl.value.trim(),
+            num_steps: parseInt(sfTtsNumSteps.value, 10),
+            guidance_scale: parseFloat(sfTtsGuidanceScale.value),
+            // 0 in form means null (no seed)
+            seed: sfTtsEnabled.checked ? parseInt(sfTtsSeed.value, 10) : 0,
+            timeout: parseFloat(sfTtsTimeout.value),
+            streaming: sfTtsStreaming.checked,
+        },
+        stt: {
+            enabled: sfSttEnabled.checked,
+            base_url: sfSttBaseUrl.value.trim(),
+            timeout: parseFloat(sfSttTimeout.value),
+        },
+    };
+}
+
+function validateSettings(data) {
+    // LLM validation
+    if (!data.llm.base_url) return "LLM Base URL is required.";
+    if (!data.llm.model) return "LLM Model is required.";
+    if (isNaN(data.llm.max_tokens) || data.llm.max_tokens < 1) return "LLM Max Tokens must be a positive number.";
+    if (isNaN(data.llm.temperature) || data.llm.temperature < 0 || data.llm.temperature > 1) {
+        return "LLM Temperature must be between 0.0 and 1.0.";
+    }
+
+    // TTS validation (only if enabled)
+    if (data.tts.enabled) {
+        if (!data.tts.base_url) return "TTS Base URL is required when TTS is enabled.";
+        if (isNaN(data.tts.num_steps) || data.tts.num_steps < 4 || data.tts.num_steps > 20) {
+            return "TTS Step Count must be between 4 and 20.";
+        }
+        if (isNaN(data.tts.guidance_scale) || data.tts.guidance_scale < 1.0 || data.tts.guidance_scale > 2.0) {
+            return "TTS CFG must be between 1.0 and 2.0.";
+        }
+        if (isNaN(data.tts.seed) || data.tts.seed < 0) {
+            return "TTS Seed must be a non-negative integer.";
+        }
+        if (isNaN(data.tts.timeout) || data.tts.timeout < 5 || data.tts.timeout > 300) {
+            return "TTS Timeout must be between 5 and 300 seconds.";
+        }
+    }
+
+    // STT validation (only if enabled)
+    if (data.stt.enabled) {
+        if (!data.stt.base_url) return "STT Base URL is required when STT is enabled.";
+        if (isNaN(data.stt.timeout) || data.stt.timeout < 5 || data.stt.timeout > 300) {
+            return "STT Timeout must be between 5 and 300 seconds.";
+        }
+    }
+
+    return null; // No errors
+}
+
+async function submitSettings(e) {
+    e.preventDefault();
+    settingsError.classList.add("hidden");
+
+    const data = collectSettingsFromForm();
+    const error = validateSettings(data);
+    if (error) {
+        return showSettingsError(error);
+    }
+
+    try {
+        const resp = await fetch("/api/settings", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(data),
+        });
+
+        if (!resp.ok) {
+            const err = await resp.json().catch(() => ({}));
+            return showSettingsError(err.detail || `Server error ${resp.status}`);
+        }
+
+        // Update in-memory TTS state based on new settings
+        ttsStreaming = data.tts.streaming;
+        // Re-check service health to update UI availability after settings change
+        await checkTTSHealth();
+        await checkSTTHealth();
+
+        closeSettings();
+    } catch (err) {
+        console.error("Failed to save settings:", err);
+        showSettingsError("Request failed. Is the server running?");
+    }
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -867,3 +867,156 @@ html, body {
     font-size: 0.9rem;
     color: var(--text-secondary);
 }
+
+/* ==========================================================================
+   Settings Modal
+   ========================================================================== */
+
+#settings-form {
+    display: flex;
+    flex-direction: column;
+}
+
+.settings-body {
+    padding: 16px 20px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    max-height: 65vh;
+}
+
+/* Fieldset sections */
+.settings-section {
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 12px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.settings-section legend {
+    padding: 0 6px;
+    font-size: 0.82rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    cursor: default;
+}
+
+/* Settings fields container (shown/hidden based on toggle) */
+.settings-fields {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.settings-fields.disabled {
+    opacity: 0.35;
+    pointer-events: none;
+}
+
+/* Toggle switch (for TTS/STT enable/disable) */
+.settings-toggle-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    user-select: none;
+}
+
+.settings-toggle {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.settings-toggle-slider {
+    position: relative;
+    display: inline-block;
+    width: 36px;
+    height: 20px;
+    background: var(--border-color);
+    border-radius: 10px;
+    transition: background 0.2s;
+    flex-shrink: 0;
+}
+
+.settings-toggle-slider::after {
+    content: "";
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 16px;
+    height: 16px;
+    background: var(--text-secondary);
+    border-radius: 50%;
+    transition: transform 0.2s, background 0.2s;
+}
+
+.settings-toggle:checked + .settings-toggle-slider {
+    background: var(--accent);
+}
+
+.settings-toggle:checked + .settings-toggle-slider::after {
+    transform: translateX(16px);
+    background: #fff;
+}
+
+.settings-toggle-text {
+    font-size: 0.82rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+/* Styled checkbox (for streaming toggle) */
+.settings-checkbox-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    user-select: none;
+}
+
+.settings-checkbox-label input[type="checkbox"] {
+    accent-color: var(--accent);
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+}
+
+/* Number input styling for settings */
+.settings-body .form-row input[type="number"] {
+    background: var(--bg-input);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 8px 10px;
+    font-size: 0.88rem;
+    font-family: inherit;
+    outline: none;
+    transition: border-color 0.15s;
+    width: 100%;
+}
+
+.settings-body .form-row input[type="number"]:focus {
+    border-color: var(--accent);
+}
+
+/* Remove spinner arrows from number inputs */
+.settings-body input[type="number"]::-webkit-inner-spin-button,
+.settings-body input[type="number"]::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+.settings-body input[type="number"] {
+    -moz-appearance: textfield;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -165,7 +165,7 @@
         <div class="modal-box">
             <div class="modal-header">
                 <h2 id="settings-title">Settings</h2>
-                <button id="settings-btn-close" class="btn-icon-close" title="Close">&#10005;</button>
+                <button id="settings-btn-close" type="button" class="btn-icon-close" title="Close" aria-label="Close settings">&#10005;</button>
             </div>
             <div id="settings-error" class="pe-form-error hidden"></div>
             <form id="settings-form" novalidate>

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,6 +20,7 @@
                     <option value="blues">Blues</option>
                 </select>
                 <button id="btn-persona-editor" title="Open persona editor">&#9998; Personas</button>
+                <button id="btn-settings" title="Open settings">&#9881; Settings</button>
                 <button id="btn-new-chat" title="Start a new chat">New Chat</button>
                 <button id="btn-tts-toggle" title="Toggle TTS playback" class="icon-btn">
                     <span id="tts-icon">&#128266;</span>
@@ -156,6 +157,112 @@
                 <button id="pe-confirm-cancel" class="btn-secondary">Cancel</button>
                 <button id="pe-confirm-delete" class="btn-danger">Delete</button>
             </div>
+        </div>
+    </div>
+
+    <!-- Settings Modal -->
+    <div id="settings-overlay" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="settings-title">
+        <div class="modal-box">
+            <div class="modal-header">
+                <h2 id="settings-title">Settings</h2>
+                <button id="settings-btn-close" class="btn-icon-close" title="Close">&#10005;</button>
+            </div>
+            <div id="settings-error" class="pe-form-error hidden"></div>
+            <form id="settings-form" novalidate>
+                <div class="settings-body">
+                    <!-- LLM Section (always enabled) -->
+                    <fieldset class="settings-section">
+                        <legend>LLM</legend>
+                        <div class="form-row">
+                            <label for="sf-llm-base-url">Base URL</label>
+                            <input id="sf-llm-base-url" type="text" required>
+                        </div>
+                        <div class="form-row">
+                            <label for="sf-llm-model">Model</label>
+                            <input id="sf-llm-model" type="text" required>
+                        </div>
+                        <div class="form-row form-row-inline">
+                            <div class="form-col">
+                                <label for="sf-llm-max-tokens">Max Tokens</label>
+                                <input id="sf-llm-max-tokens" type="number" min="1" required>
+                            </div>
+                            <div class="form-col">
+                                <label for="sf-llm-temperature">Temperature</label>
+                                <input id="sf-llm-temperature" type="number" min="0" max="1" step="0.01" required>
+                            </div>
+                        </div>
+                    </fieldset>
+
+                    <!-- TTS Section -->
+                    <fieldset class="settings-section">
+                        <legend>
+                            <label class="settings-toggle-label">
+                                <input id="sf-tts-enabled" type="checkbox" class="settings-toggle">
+                                <span class="settings-toggle-slider"></span>
+                                <span class="settings-toggle-text">TTS</span>
+                            </label>
+                        </legend>
+                        <div id="sf-tts-fields" class="settings-fields">
+                            <div class="form-row">
+                                <label for="sf-tts-base-url">Base URL</label>
+                                <input id="sf-tts-base-url" type="text">
+                            </div>
+                            <div class="form-row form-row-inline">
+                                <div class="form-col">
+                                    <label for="sf-tts-num-steps">Step Count <span class="field-hint">(4–20)</span></label>
+                                    <input id="sf-tts-num-steps" type="number" min="4" max="20">
+                                </div>
+                                <div class="form-col">
+                                    <label for="sf-tts-guidance-scale">CFG <span class="field-hint">(1.0–2.0)</span></label>
+                                    <input id="sf-tts-guidance-scale" type="number" min="1.0" max="2.0" step="0.1">
+                                </div>
+                            </div>
+                            <div class="form-row form-row-inline">
+                                <div class="form-col">
+                                    <label for="sf-tts-seed">Seed <span class="field-hint">(0 = random)</span></label>
+                                    <input id="sf-tts-seed" type="number" min="0">
+                                </div>
+                                <div class="form-col">
+                                    <label for="sf-tts-timeout">Timeout <span class="field-hint">(5–300s)</span></label>
+                                    <input id="sf-tts-timeout" type="number" min="5" max="300">
+                                </div>
+                            </div>
+                            <div class="form-row">
+                                <label class="settings-checkbox-label">
+                                    <input id="sf-tts-streaming" type="checkbox">
+                                    <span>Streaming (sentence-by-sentence)</span>
+                                </label>
+                            </div>
+                        </div>
+                    </fieldset>
+
+                    <!-- STT Section -->
+                    <fieldset class="settings-section">
+                        <legend>
+                            <label class="settings-toggle-label">
+                                <input id="sf-stt-enabled" type="checkbox" class="settings-toggle">
+                                <span class="settings-toggle-slider"></span>
+                                <span class="settings-toggle-text">STT</span>
+                            </label>
+                        </legend>
+                        <div id="sf-stt-fields" class="settings-fields">
+                            <div class="form-row">
+                                <label for="sf-stt-base-url">Base URL</label>
+                                <input id="sf-stt-base-url" type="text">
+                            </div>
+                            <div class="form-row">
+                                <label for="sf-stt-timeout">Timeout <span class="field-hint">(5–300s)</span></label>
+                                <input id="sf-stt-timeout" type="number" min="5" max="300">
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+
+                <div class="form-actions">
+                    <button type="button" id="settings-btn-cancel" class="btn-secondary">Cancel</button>
+                    <button type="submit" id="settings-btn-save" class="btn-accent">Save</button>
+                </div>
+            </form>
         </div>
     </div>
 


### PR DESCRIPTION
This PR addresses issue #23 by adding a UI for viewing/editing server connection settings. Changes are committed to `settings.yaml` immediately and are used from that point on.

Also fixed a bug where the microphone button's enabled/disabled state was not reflecting the availability of a STT server.