### PR TITLE
Issue #18 - chat rooms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # TalkWithMe
 
 A local single-user chat web application that connects to a locally running **llama.cpp** server and supports **multi-persona group chats** with optional **TTS playback**.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # TalkWithMe
 
 A local single-user chat web application that connects to a locally running **llama.cpp** server and supports **multi-persona group chats** with optional **TTS playback**.
@@ -207,6 +208,7 @@ If you want to hear each sentence as soon as it has been synthesized, without ha
   - Split TTS and STT into separate features with separate configuration (#19)
   - Add UI for server connection settings (#23)
   - Clicking a persona now updates "Who should answer?" to "Selected persona" (#24)
+  - Added configurable chat rooms for grouping personas (#18)
 
 ## License
 

--- a/app/config.py
+++ b/app/config.py
@@ -95,12 +95,27 @@ class PersonasConfig(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Chat Rooms
+# ---------------------------------------------------------------------------
+
+class ChatRoom(BaseModel):
+    """A named grouping of personas."""
+    name: str
+    persona_names: List[str] = Field(default_factory=list)
+
+
+class ChatRoomsConfig(BaseModel):
+    chat_rooms: List[ChatRoom] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
 # Loading helpers
 # ---------------------------------------------------------------------------
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 _settings_cache: Optional[AppSettings] = None
 _personas_cache: Optional[PersonasConfig] = None
+_chatrooms_cache: Optional[ChatRoomsConfig] = None
 
 
 def load_settings(path: Optional[Path] = None) -> AppSettings:
@@ -176,10 +191,48 @@ def save_settings(config: AppSettings, path: Optional[Path] = None) -> None:
     _settings_cache = config
 
 
+def get_chatrooms() -> ChatRoomsConfig:
+    """Return cached chat rooms, loading if necessary."""
+    if _chatrooms_cache is None:
+        return load_chatrooms()
+    return _chatrooms_cache
+
+
+def load_chatrooms(path: Optional[Path] = None) -> ChatRoomsConfig:
+    """Parse chatrooms.yaml. Returns empty config if file is missing."""
+    global _chatrooms_cache
+    target = path or _PROJECT_ROOT / "chatrooms.yaml"
+    if not target.exists():
+        return ChatRoomsConfig()
+    with open(target) as f:
+        raw = yaml.safe_load(f) or {}
+    _chatrooms_cache = ChatRoomsConfig(
+        chat_rooms=[ChatRoom(**cr) for cr in raw.get("chat_rooms", [])]
+    )
+    return _chatrooms_cache
+
+
+def save_chatrooms(config: ChatRoomsConfig, path: Optional[Path] = None) -> None:
+    """Serialize ChatRoomsConfig back to chatrooms.yaml and update the in-memory cache."""
+    global _chatrooms_cache
+    target = path or _PROJECT_ROOT / "chatrooms.yaml"
+    raw = {
+        "chat_rooms": [
+            cr.model_dump(exclude_none=False)
+            for cr in config.chat_rooms
+        ]
+    }
+    with open(target, "w") as f:
+        yaml.dump(raw, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+    _chatrooms_cache = config
+
+
 def reload_all():
-    """Force-reload both config files. Useful for dev hot-reload."""
-    global _settings_cache, _personas_cache
+    """Force-reload all config files. Useful for dev hot-reload."""
+    global _settings_cache, _personas_cache, _chatrooms_cache
     _settings_cache = None
     _personas_cache = None
+    _chatrooms_cache = None
     load_settings()
     load_personas()
+    load_chatrooms()

--- a/app/main.py
+++ b/app/main.py
@@ -14,7 +14,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from app import config as app_config
-from app.routers import chat, personas, session as session_router, settings, stt, tts
+from app.routers import chat, chatrooms, personas, session as session_router, settings, stt, tts
 from app.session import session
 
 logger = logging.getLogger(__name__)
@@ -29,6 +29,7 @@ async def lifespan(app: FastAPI):
     # Load configuration files
     personas_cfg = app_config.load_personas()
     settings = app_config.load_settings()
+    app_config.load_chatrooms()
 
     # Seed session with all configured personas as active
     all_names = [p.name for p in personas_cfg.personas]
@@ -59,6 +60,7 @@ app.mount("/static", StaticFiles(directory=str(Path(__file__).resolve().parent.p
 
 # Register routers
 app.include_router(personas.router)
+app.include_router(chatrooms.router)
 app.include_router(session_router.router)
 app.include_router(chat.router)
 app.include_router(tts.router)

--- a/app/models.py
+++ b/app/models.py
@@ -206,3 +206,23 @@ class ChatMessage(BaseModel):
     content: str
     # Which persona produced this message (only set for assistant messages)
     persona: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Chat Room models
+# ---------------------------------------------------------------------------
+
+class ChatRoomResponse(BaseModel):
+    """A chat room returned to the frontend."""
+    name: str
+    persona_names: List[str] = Field(default_factory=list)
+
+
+class ChatRoomCreateRequest(BaseModel):
+    """Create a new chat room."""
+    name: str = Field(..., min_length=1, max_length=20)
+
+
+class AssignPersonasRequest(BaseModel):
+    """Assign personas to a chat room."""
+    persona_names: List[str] = Field(..., min_length=1)

--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -28,13 +28,14 @@ router = APIRouter(prefix="/api/chat", tags=["chat"])
 
 def _build_router_prompt(user_message: str) -> list[dict]:
     """Build a minimal prompt that asks the LLM to pick a persona by name."""
-    active = session.active_personas or [p.name for p in get_personas().personas]
-    active_personas = [p for p in get_personas().personas if p.name in active]
+    personas_config = get_personas().personas
+    active = session.active_personas or [p.name for p in personas_config]
+    active_personas = [p for p in personas_config if p.name in active]
     persona_choices = ", ".join(p.name for p in active_personas)
 
     # Build router hints block
     hints = "\n".join(
-        f"- {p.name}: {p.router_hints}" for p in config.personas
+        f"- {p.name}: {p.router_hints}" for p in personas_config
     )
 
     # Include last N conversation turns for context

--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -28,8 +28,9 @@ router = APIRouter(prefix="/api/chat", tags=["chat"])
 
 def _build_router_prompt(user_message: str) -> list[dict]:
     """Build a minimal prompt that asks the LLM to pick a persona by name."""
-    config = get_personas()
-    persona_choices = ", ".join(p.name for p in config.personas)
+    active = session.active_personas or [p.name for p in get_personas().personas]
+    active_personas = [p for p in get_personas().personas if p.name in active]
+    persona_choices = ", ".join(p.name for p in active_personas)
 
     # Build router hints block
     hints = "\n".join(
@@ -88,7 +89,7 @@ async def _pick_persona(who_answers: str, user_message: str) -> str:
         return random.choice(active)
 
     # Explicit persona name — validate it exists
-    if who_answers in all_names:
+    if who_answers in active:
         return who_answers
 
     # Unknown value — fall back to random

--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -81,7 +81,7 @@ async def _pick_persona(who_answers: str, user_message: str) -> str:
             result = await chat_completion(prompt, max_tokens=16)
             chosen = result.strip().strip("\"'")
             # Validate the LLM actually returned a known name
-            if chosen in all_names:
+            if chosen in active:
                 return chosen
             logger.info("Router returned unknown name '%s', falling back to random", chosen)
         except Exception as exc:

--- a/app/routers/chatrooms.py
+++ b/app/routers/chatrooms.py
@@ -61,6 +61,8 @@ def create_chatroom(req: ChatRoomCreateRequest):
     - New rooms start with zero personas assigned.
     """
     name = req.name.strip()
+    if not name:
+        raise HTTPException(status_code=422, detail="Room name is required.")
     if name.lower() == DEFAULT_ROOM:
         raise HTTPException(
             status_code=409,

--- a/app/routers/chatrooms.py
+++ b/app/routers/chatrooms.py
@@ -1,0 +1,169 @@
+"""Chat rooms router — CRUD for chat rooms and persona assignment.
+
+Chat rooms let users group personas into logical collections. The implicit
+"default" room always exists and contains all personas; it cannot be created,
+edited, or deleted via this API.
+"""
+
+import logging
+import re
+from typing import List
+
+from fastapi import APIRouter, HTTPException
+
+from app.config import (
+    ChatRoom,
+    ChatRoomsConfig,
+    get_chatrooms,
+    get_personas,
+    save_chatrooms,
+)
+from app.models import (
+    AssignPersonasRequest,
+    ChatRoomCreateRequest,
+    ChatRoomResponse,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/chatrooms", tags=["chatrooms"])
+
+DEFAULT_ROOM = "default"
+
+
+def _to_response(room: ChatRoom) -> ChatRoomResponse:
+    return ChatRoomResponse(name=room.name, persona_names=list(room.persona_names))
+
+
+@router.get("", response_model=List[ChatRoomResponse])
+def list_chatrooms():
+    """Return all configured chat rooms (excluding the implicit 'default')."""
+    return [_to_response(r) for r in get_chatrooms().chat_rooms]
+
+
+@router.get("/all", response_model=List[ChatRoomResponse])
+def list_all_chatrooms():
+    """Return all chat rooms including the implicit 'default'.
+    Used by the frontend to populate the dropdown."""
+    config = get_chatrooms()
+    # "default" room always contains all configured personas
+    all_persona_names = [p.name for p in get_personas().personas]
+    result = [ChatRoomResponse(name=DEFAULT_ROOM, persona_names=all_persona_names)]
+    result.extend(_to_response(r) for r in config.chat_rooms)
+    return result
+
+
+@router.post("", response_model=ChatRoomResponse, status_code=201)
+def create_chatroom(req: ChatRoomCreateRequest):
+    """Create a new chat room.
+
+    - Name is case-insensitive for uniqueness checks.
+    - 'default' (or any case variation) is reserved and rejected.
+    - New rooms start with zero personas assigned.
+    """
+    name = req.name.strip()
+    if name.lower() == DEFAULT_ROOM:
+        raise HTTPException(
+            status_code=409,
+            detail=f"'{DEFAULT_ROOM}' is a reserved chat room name and cannot be created.",
+        )
+    if not re.match(r'^[a-zA-Z0-9 _-]+$', name):
+        raise HTTPException(status_code=422, detail="Room name contains invalid characters.")
+
+    config = get_chatrooms()
+    if any(r.name.lower() == name.lower() for r in config.chat_rooms):
+        raise HTTPException(
+            status_code=409,
+            detail=f"A chat room named '{name}' already exists.",
+        )
+
+    new_room = ChatRoom(name=name, persona_names=[])
+    save_chatrooms(ChatRoomsConfig(chat_rooms=config.chat_rooms + [new_room]))
+    return _to_response(new_room)
+
+
+@router.delete("/{name}", status_code=204)
+def delete_chatroom(name: str):
+    """Delete a chat room. The 'default' room cannot be deleted."""
+    if name.lower() == DEFAULT_ROOM:
+        raise HTTPException(
+            status_code=400,
+            detail=f"The '{DEFAULT_ROOM}' chat room cannot be deleted.",
+        )
+
+    config = get_chatrooms()
+    if not any(r.name.lower() == name.lower() for r in config.chat_rooms):
+        raise HTTPException(status_code=404, detail=f"Chat room '{name}' not found.")
+
+    save_chatrooms(
+        ChatRoomsConfig(
+            chat_rooms=[r for r in config.chat_rooms if r.name.lower() != name.lower()]
+        )
+    )
+
+
+@router.get("/{name}", response_model=ChatRoomResponse)
+def get_chatroom(name: str):
+    """Return a specific chat room's details, including 'default'."""
+    if name.lower() == DEFAULT_ROOM:
+        all_persona_names = [p.name for p in get_personas().personas]
+        return ChatRoomResponse(name=DEFAULT_ROOM, persona_names=all_persona_names)
+
+    config = get_chatrooms()
+    room = next((r for r in config.chat_rooms if r.name.lower() == name.lower()), None)
+    if not room:
+        raise HTTPException(status_code=404, detail=f"Chat room '{name}' not found.")
+    return _to_response(room)
+
+
+@router.put("/{name}/personas", response_model=ChatRoomResponse)
+def assign_personas(name: str, req: AssignPersonasRequest):
+    """Add personas to a chat room. Cannot modify the 'default' room."""
+    if name.lower() == DEFAULT_ROOM:
+        raise HTTPException(
+            status_code=400,
+            detail=f"The '{DEFAULT_ROOM}' chat room cannot be modified.",
+        )
+
+    config = get_chatrooms()
+    room = next((r for r in config.chat_rooms if r.name.lower() == name.lower()), None)
+    if not room:
+        raise HTTPException(status_code=404, detail=f"Chat room '{name}' not found.")
+
+    # Validate that requested personas actually exist
+    valid_names = {p.name for p in get_personas().personas}
+    for pname in req.persona_names:
+        if pname not in valid_names:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Persona '{pname}' does not exist.",
+            )
+
+    # Add new personas (avoid duplicates)
+    existing = set(room.persona_names)
+    updated_names = list(existing) + [p for p in req.persona_names if p not in existing]
+
+    updated_room = ChatRoom(name=room.name, persona_names=updated_names)
+    updated_rooms = [updated_room if r.name == room.name else r for r in config.chat_rooms]
+    save_chatrooms(ChatRoomsConfig(chat_rooms=updated_rooms))
+    return _to_response(updated_room)
+
+
+@router.delete("/{name}/personas/{persona_name}", response_model=ChatRoomResponse)
+def remove_persona_from_room(name: str, persona_name: str):
+    """Remove a persona from a chat room. Cannot modify the 'default' room."""
+    if name.lower() == DEFAULT_ROOM:
+        raise HTTPException(
+            status_code=400,
+            detail=f"The '{DEFAULT_ROOM}' chat room cannot be modified.",
+        )
+
+    config = get_chatrooms()
+    room = next((r for r in config.chat_rooms if r.name.lower() == name.lower()), None)
+    if not room:
+        raise HTTPException(status_code=404, detail=f"Chat room '{name}' not found.")
+
+    updated_names = [p for p in room.persona_names if p != persona_name]
+    updated_room = ChatRoom(name=room.name, persona_names=updated_names)
+    updated_rooms = [updated_room if r.name == room.name else r for r in config.chat_rooms]
+    save_chatrooms(ChatRoomsConfig(chat_rooms=updated_rooms))
+    return _to_response(updated_room)

--- a/app/routers/chatrooms.py
+++ b/app/routers/chatrooms.py
@@ -138,9 +138,11 @@ def assign_personas(name: str, req: AssignPersonasRequest):
                 detail=f"Persona '{pname}' does not exist.",
             )
 
-    # Add new personas (avoid duplicates)
-    existing = set(room.persona_names)
-    updated_names = list(existing) + [p for p in req.persona_names if p not in existing]
+    # Add new personas (avoid duplicates, preserving existing order)
+    updated_names = list(room.persona_names)
+    for pname in req.persona_names:
+        if pname not in updated_names:
+            updated_names.append(pname)
 
     updated_room = ChatRoom(name=room.name, persona_names=updated_names)
     updated_rooms = [updated_room if r.name == room.name else r for r in config.chat_rooms]

--- a/app/routers/personas.py
+++ b/app/routers/personas.py
@@ -7,12 +7,53 @@ from typing import List
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import FileResponse, Response
 
-from app.config import get_personas, save_personas
+from app.config import (
+    ChatRoom,
+    ChatRoomsConfig,
+    get_chatrooms,
+    get_personas,
+    save_chatrooms,
+    save_personas,
+)
 from app.config import Persona, PersonasConfig
 from app.models import PersonaResponse, PersonaDetailResponse, PersonaCreateRequest, PersonaUpdateRequest
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/personas", tags=["personas"])
+
+
+def _cascade_persona_rename(old_name: str, new_name: str) -> None:
+    """Update persona name references in all chat rooms.
+
+    When a persona is renamed, every chat room that references it
+    must be updated to use the new name so assignments stay valid.
+    """
+    config = get_chatrooms()
+    if not config.chat_rooms:
+        return
+    updated = []
+    for room in config.chat_rooms:
+        new_names = [new_name if p == old_name else p for p in room.persona_names]
+        updated.append(ChatRoom(name=room.name, persona_names=new_names))
+    save_chatrooms(ChatRoomsConfig(chat_rooms=updated))
+    logger.info("Cascaded persona rename '%s' -> '%s' to chat rooms", old_name, new_name)
+
+
+def _cascade_persona_delete(persona_name: str) -> None:
+    """Remove a persona from all chat rooms.
+
+    When a persona is deleted, it must be removed from every chat room
+    that had it assigned to avoid dangling references.
+    """
+    config = get_chatrooms()
+    if not config.chat_rooms:
+        return
+    updated = []
+    for room in config.chat_rooms:
+        new_names = [p for p in room.persona_names if p != persona_name]
+        updated.append(ChatRoom(name=room.name, persona_names=new_names))
+    save_chatrooms(ChatRoomsConfig(chat_rooms=updated))
+    logger.info("Cascaded persona delete '%s' from chat rooms", persona_name)
 
 
 def _to_response(p: Persona) -> PersonaResponse:
@@ -110,16 +151,23 @@ def update_persona(name: str, req: PersonaUpdateRequest):
     )
     new_list = [updated_persona if p.name == name else p for p in config.personas]
     save_personas(PersonasConfig(personas=new_list))
+
+    # If the persona was renamed, update all chat rooms referencing it
+    if new_name != name:
+        _cascade_persona_rename(name, new_name)
+
     return _to_detail(updated_persona)
 
 
 @router.delete("/{name}", status_code=204)
 def delete_persona(name: str):
-    """Remove a persona from personas.yaml."""
+    """Remove a persona from personas.yaml and all chat rooms."""
     config = get_personas()
     if not any(p.name == name for p in config.personas):
         raise HTTPException(status_code=404, detail=f"Persona '{name}' not found")
     save_personas(PersonasConfig(personas=[p for p in config.personas if p.name != name]))
+    # Remove this persona from every chat room that had it assigned
+    _cascade_persona_delete(name)
 
 
 @router.post("/{name}/clone", response_model=PersonaDetailResponse, status_code=201)

--- a/chatrooms.yaml
+++ b/chatrooms.yaml
@@ -1,0 +1,5 @@
+chat_rooms:
+- name: Test
+  persona_names:
+  - Luna
+  - Alex

--- a/static/app.js
+++ b/static/app.js
@@ -1493,7 +1493,7 @@ function renderPersonaPickerList() {
         checkbox.checked = false;
         checkbox.addEventListener("click", (e) => {
             e.stopPropagation();
-            togglePickerSelection(p.name, checkbox.checked, e.target);
+            togglePickerSelection(p.name, checkbox.checked, item);
         });
 
         const avatar = document.createElement("div");

--- a/static/app.js
+++ b/static/app.js
@@ -6,8 +6,8 @@
  */
 
 /* ==========================================================================
-   State
-   ========================================================================== */
+    State
+    ========================================================================== */
 
 let personas = [];
 let selectedPersona = null;   // The persona selected in the sidebar
@@ -16,6 +16,11 @@ let ttsAvailable = false;      // Whether the TTS server is reachable
 let ttsStreaming = false;       // Whether streaming (sentence-by-sentence) TTS is enabled
 let sttAvailable = false;      // Whether the STT server is reachable
 let isStreaming = false;       // Guard: prevent double-sends during streaming
+
+// Chat room state
+let currentChatRoom = "default";       // Currently selected chat room
+let allChatRooms = [];                 // Full list of rooms (including "default")
+let roomPersonas = {};                 // Map: room name -> list of persona names
 
 // Microphone / STT state
 let mediaRecorder = null;
@@ -52,16 +57,21 @@ const personaListEl = document.getElementById("persona-list");
 const whoChooser = document.getElementById("who-chooser");
 const themeSelectEl = document.getElementById("theme-select");
 
+// Chat room DOM references
+const chatRoomDropdown = document.getElementById("chat-room-dropdown");
+const btnAddPersona = document.getElementById("btn-add-persona");
+
 /* ==========================================================================
    Initialization
    ========================================================================== */
 
 async function init() {
     initTheme();
-    await loadPersonas();
+    await loadPersonas(); // Also loads chat rooms internally
     await checkTTSHealth();
     await checkSTTHealth();
     setupEventListeners();
+    setupChatRoomEventListeners();
     showEmptyState();
 }
 
@@ -69,21 +79,94 @@ async function loadPersonas() {
     try {
         const resp = await fetch("/api/personas");
         personas = await resp.json();
-        renderPersonaList();
-        // Default: select first persona
-        if (personas.length > 0) {
-            selectedPersona = personas[0].name;
-            highlightSelectedPersona();
-        }
-        // Activate all personas in the session
-        await fetch("/api/session/personas", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ active_personas: personas.map(p => p.name) }),
-        });
+        // After loading personas, also refresh chat rooms so the persona lists
+        // in each room are up to date (handles rename/delete cascades).
+        await loadChatRooms();
     } catch (err) {
         console.error("Failed to load personas:", err);
     }
+}
+
+/**
+ * Load all chat rooms from the server and initialize the room state.
+ * After loading, applies the current room filter and renders the persona list.
+ */
+async function loadChatRooms() {
+    try {
+        const resp = await fetch("/api/chatrooms/all");
+        allChatRooms = await resp.json();
+
+        // Build the persona map
+        roomPersonas = {};
+        for (const room of allChatRooms) {
+            roomPersonas[room.name] = room.persona_names;
+        }
+
+        // Populate the dropdown
+        renderChatRoomDropdown();
+
+        // If previously selected room no longer exists, revert to default
+        const roomExists = allChatRooms.some(r => r.name === currentChatRoom);
+        if (!roomExists && allChatRooms.length > 0) {
+            currentChatRoom = "default";
+            chatRoomDropdown.value = "default";
+        }
+
+        // Apply the current room filter and render
+        applyChatRoomFilter();
+    } catch (err) {
+        console.error("Failed to load chat rooms:", err);
+        // Fallback: show all personas in "default" room
+        currentChatRoom = "default";
+        renderPersonaList();
+    }
+}
+
+/**
+ * Apply the current chat room filter: update persona list, active session,
+ * and UI controls (add/remove buttons).
+ */
+function applyChatRoomFilter() {
+    const isActiveRoom = currentChatRoom !== "default";
+    const roomPersonaNames = roomPersonas[currentChatRoom] || [];
+
+    // Filter the persona list to only those in this room
+    const filtered = isActiveRoom
+        ? personas.filter(p => roomPersonaNames.includes(p.name))
+        : [...personas];
+
+    // Update the persona list rendering
+    renderPersonaList(filtered, isActiveRoom);
+
+    // Select first persona if none selected or selected one not in room
+    if (filtered.length > 0) {
+        if (!selectedPersona || !filtered.some(p => p.name === selectedPersona)) {
+            selectedPersona = filtered[0].name;
+        }
+        highlightSelectedPersona();
+    } else {
+        selectedPersona = null;
+    }
+
+    // Activate only the room's personas in the session
+    const activeNames = filtered.map(p => p.name);
+    if (activeNames.length > 0) {
+        fetch("/api/session/personas", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ active_personas: activeNames }),
+        }).catch(err => console.error("Failed to update session personas:", err));
+    }
+
+    // Show/hide the "Add persona" button
+    if (isActiveRoom) {
+        btnAddPersona.classList.remove("hidden");
+    } else {
+        btnAddPersona.classList.add("hidden");
+    }
+
+    // Update dropdown selection
+    chatRoomDropdown.value = currentChatRoom;
 }
 
 async function checkTTSHealth() {
@@ -183,22 +266,20 @@ function applyTheme(theme, persist) {
    Persona list rendering
    ========================================================================== */
 
-function renderPersonaList() {
+/**
+ * Render the persona list in the sidebar.
+ * @param {Array} [list] - Optional filtered list. If omitted, uses all personas.
+ * @param {boolean} [showRemoveButtons] - Whether to show the remove "x" button per persona.
+ */
+function renderPersonaList(list, showRemoveButtons) {
     personaListEl.innerHTML = "";
-    for (const p of personas) {
+    const personaList = list || personas;
+    const showRemove = !!showRemoveButtons;
+
+    for (const p of personaList) {
         const card = document.createElement("div");
         card.className = "persona-card";
         card.dataset.name = p.name;
-        card.addEventListener("click", () => {
-            selectedPersona = p.name;
-            highlightSelectedPersona();
-            // If I clicked a persona, I probably want it to answer. Switch the chooser.
-            const selectedRadio = document.querySelector('input[name="who_answers"][value="selected"]');
-            if (selectedRadio) {
-                selectedRadio.checked = true;
-                selectedRadio.dispatchEvent(new Event("change", { bubbles: true }));
-            }
-        });
 
         // Avatar
         const avatar = document.createElement("div");
@@ -244,6 +325,34 @@ function renderPersonaList() {
 
         card.appendChild(avatar);
         card.appendChild(info);
+
+        // Click handler for selecting persona (on the card, not the remove button)
+        card.addEventListener("click", (e) => {
+            // Don't trigger selection when clicking the remove button
+            if (e.target.classList.contains("persona-remove-btn")) return;
+            selectedPersona = p.name;
+            highlightSelectedPersona();
+            // If I clicked a persona, I probably want it to answer. Switch the chooser.
+            const selectedRadio = document.querySelector('input[name="who_answers"][value="selected"]');
+            if (selectedRadio) {
+                selectedRadio.checked = true;
+                selectedRadio.dispatchEvent(new Event("change", { bubbles: true }));
+            }
+        });
+
+        // Remove button (only for non-default rooms)
+        if (showRemove) {
+            const removeBtn = document.createElement("button");
+            removeBtn.className = "persona-remove-btn";
+            removeBtn.textContent = "\u2715";  // ×
+            removeBtn.title = `Remove ${p.name} from this chat room`;
+            removeBtn.addEventListener("click", (e) => {
+                e.stopPropagation();
+                removePersonaFromRoom(p.name);
+            });
+            card.appendChild(removeBtn);
+        }
+
         personaListEl.appendChild(card);
     }
 }
@@ -280,6 +389,13 @@ function getWhoAnswers() {
 async function sendMessage() {
     const text = inputEl.value.trim();
     if (!text || isStreaming) return;
+
+    // If the current chat room has no personas, show an error instead of sending
+    const roomPersonaNames = roomPersonas[currentChatRoom] || [];
+    if (roomPersonaNames.length === 0) {
+        appendErrorBubble("No one is here.");
+        return;
+    }
 
     // Clear empty state if present
     if (messagesEl.querySelector(".empty-state")) {
@@ -1076,8 +1192,385 @@ function escapeHtml(str) {
 }
 
 /* ==========================================================================
-   Settings Modal
-   ========================================================================== */
+    Chat Rooms
+    ========================================================================== */
+
+/**
+ * Populate the chat room dropdown from the server's full list.
+ */
+function renderChatRoomDropdown() {
+    chatRoomDropdown.innerHTML = "";
+    for (const room of allChatRooms) {
+        const opt = document.createElement("option");
+        opt.value = room.name;
+        opt.textContent = room.name === "default" ? "All Personas" : room.name;
+        chatRoomDropdown.appendChild(opt);
+    }
+}
+
+function setupChatRoomEventListeners() {
+    // Dropdown change: switch rooms
+    chatRoomDropdown.addEventListener("change", () => {
+        switchChatRoom(chatRoomDropdown.value);
+    });
+
+    // "Add persona" button in sidebar
+    btnAddPersona.addEventListener("click", openPersonaPicker);
+
+    // Chat rooms editor button in topbar
+    document.getElementById("btn-chat-rooms").addEventListener("click", openChatRoomsEditor);
+    document.getElementById("cr-btn-close").addEventListener("click", closeChatRoomsEditor);
+
+    // New room form
+    document.getElementById("cr-btn-new").addEventListener("click", showNewRoomForm);
+    document.getElementById("cr-new-cancel").addEventListener("click", hideNewRoomForm);
+    document.getElementById("cr-new-save").addEventListener("click", createChatRoom);
+
+    // Delete confirmation
+    document.getElementById("cr-confirm-cancel").addEventListener("click", () => {
+        document.getElementById("cr-confirm-overlay").classList.add("hidden");
+    });
+
+    // Backdrop click to close
+    document.getElementById("chatrooms-overlay").addEventListener("click", (e) => {
+        if (e.target === document.getElementById("chatrooms-overlay")) closeChatRoomsEditor();
+    });
+    document.getElementById("cr-confirm-overlay").addEventListener("click", (e) => {
+        if (e.target === document.getElementById("cr-confirm-overlay")) {
+            document.getElementById("cr-confirm-overlay").classList.add("hidden");
+        }
+    });
+
+    // Persona picker
+    document.getElementById("pp-btn-close").addEventListener("click", closePersonaPicker);
+    document.getElementById("pp-btn-cancel").addEventListener("click", closePersonaPicker);
+    document.getElementById("pp-btn-add").addEventListener("click", addSelectedPersonasToRoom);
+    document.getElementById("persona-picker-overlay").addEventListener("click", (e) => {
+        if (e.target === document.getElementById("persona-picker-overlay")) closePersonaPicker();
+    });
+}
+
+/**
+ * Switch to a different chat room. Clears the chat panel and updates the
+ * persona list to match the room's assigned personas.
+ */
+function switchChatRoom(roomName) {
+    currentChatRoom = roomName;
+
+    // Clear chat panel — same as "New Chat"
+    messagesEl.innerHTML = "";
+    showEmptyState();
+
+    // Reset session history on backend
+    fetch("/api/session/new", { method: "POST" })
+        .catch(err => console.error("Failed to reset session:", err));
+
+    // Re-apply filter
+    applyChatRoomFilter();
+}
+
+/**
+ * Remove a persona from the current chat room.
+ */
+async function removePersonaFromRoom(personaName) {
+    if (currentChatRoom === "default") return; // Shouldn't happen, but guard anyway
+
+    try {
+        const resp = await fetch(
+            `/api/chatrooms/${encodeURIComponent(currentChatRoom)}/personas/${encodeURIComponent(personaName)}`,
+            { method: "DELETE" }
+        );
+        if (!resp.ok) {
+            console.error("Failed to remove persona from room:", resp.status);
+            return;
+        }
+        // Update local state
+        if (roomPersonas[currentChatRoom]) {
+            roomPersonas[currentChatRoom] = roomPersonas[currentChatRoom].filter(
+                p => p !== personaName
+            );
+        }
+        // If the removed persona was selected, clear selection
+        if (selectedPersona === personaName) {
+            const roomNames = roomPersonas[currentChatRoom] || [];
+            selectedPersona = roomNames.length > 0 ? roomNames[0] : null;
+        }
+        applyChatRoomFilter();
+    } catch (err) {
+        console.error("Remove persona from room error:", err);
+    }
+}
+
+/* --------------------------------------------------------------------------
+   Chat Rooms Editor Modal
+   -------------------------------------------------------------------------- */
+
+function openChatRoomsEditor() {
+    hideNewRoomForm();
+    document.getElementById("chatrooms-overlay").classList.remove("hidden");
+    document.getElementById("cr-form-error").classList.add("hidden");
+    renderChatRoomList();
+}
+
+function closeChatRoomsEditor() {
+    document.getElementById("chatrooms-overlay").classList.add("hidden");
+    // Refresh the dropdown and re-apply room filter (in case rooms were deleted)
+    loadChatRooms();
+}
+
+function renderChatRoomList() {
+    const listEl = document.getElementById("cr-list");
+    listEl.innerHTML = "";
+
+    // Only show non-default rooms
+    const rooms = allChatRooms.filter(r => r.name !== "default");
+
+    if (rooms.length === 0) {
+        listEl.innerHTML = '<p class="cr-empty">No chat rooms yet. Click &ldquo;+ New Room&rdquo; to create one.</p>';
+        return;
+    }
+
+    for (const room of rooms) {
+        const item = document.createElement("div");
+        item.className = "cr-list-item";
+
+        const nameEl = document.createElement("span");
+        nameEl.className = "cr-list-item-name";
+        nameEl.textContent = room.name;
+
+        const countEl = document.createElement("span");
+        countEl.className = "cr-list-item-count";
+        countEl.textContent = `${room.persona_names.length} persona${room.persona_names.length !== 1 ? 's' : ''}`;
+
+        const deleteBtn = document.createElement("button");
+        deleteBtn.className = "cr-list-item-delete";
+        deleteBtn.textContent = "Delete";
+        deleteBtn.title = `Delete "${room.name}"`;
+        deleteBtn.addEventListener("click", () => confirmDeleteChatRoom(room.name));
+
+        item.appendChild(nameEl);
+        item.appendChild(countEl);
+        item.appendChild(deleteBtn);
+        listEl.appendChild(item);
+    }
+}
+
+function showNewRoomForm() {
+    document.getElementById("cr-new-form").classList.remove("hidden");
+    document.getElementById("cr-list").classList.add("hidden");
+    document.getElementById("cr-name-input").value = "";
+    document.getElementById("cr-form-error").classList.add("hidden");
+    const input = document.getElementById("cr-name-input");
+    input.focus();
+    // Allow Enter key to create the room
+    input.onkeydown = (e) => {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            createChatRoom();
+        }
+    };
+}
+
+function hideNewRoomForm() {
+    document.getElementById("cr-new-form").classList.add("hidden");
+    document.getElementById("cr-list").classList.remove("hidden");
+}
+
+async function createChatRoom() {
+    const name = document.getElementById("cr-name-input").value.trim();
+    const errorEl = document.getElementById("cr-form-error");
+
+    if (!name) {
+        errorEl.textContent = "Room name is required.";
+        errorEl.classList.remove("hidden");
+        return;
+    }
+    if (name.length > 20) {
+        errorEl.textContent = "Room name must be 20 characters or fewer.";
+        errorEl.classList.remove("hidden");
+        return;
+    }
+    if (name.toLowerCase() === "default") {
+        errorEl.textContent = "'default' is a reserved name and cannot be used.";
+        errorEl.classList.remove("hidden");
+        return;
+    }
+
+    try {
+        const resp = await fetch("/api/chatrooms", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ name }),
+        });
+
+        if (!resp.ok) {
+            const err = await resp.json().catch(() => ({}));
+            errorEl.textContent = err.detail || `Error ${resp.status}`;
+            errorEl.classList.remove("hidden");
+            return;
+        }
+
+        hideNewRoomForm();
+        // Reload rooms to refresh the list
+        await loadChatRooms();
+        renderChatRoomList();
+    } catch (err) {
+        errorEl.textContent = "Request failed. Is the server running?";
+        errorEl.classList.remove("hidden");
+    }
+}
+
+function confirmDeleteChatRoom(name) {
+    const overlay = document.getElementById("cr-confirm-overlay");
+    const msgEl = document.getElementById("cr-confirm-msg");
+    msgEl.textContent = `Delete chat room "${name}"? Personas will not be deleted, only unassigned from this room.`;
+    overlay.classList.remove("hidden");
+
+    const deleteBtn = document.getElementById("cr-confirm-delete");
+    const newBtn = deleteBtn.cloneNode(true);
+    deleteBtn.parentNode.replaceChild(newBtn, deleteBtn);
+    newBtn.addEventListener("click", () => deleteChatRoom(name));
+}
+
+async function deleteChatRoom(name) {
+    document.getElementById("cr-confirm-overlay").classList.add("hidden");
+    try {
+        const resp = await fetch(`/api/chatrooms/${encodeURIComponent(name)}`, { method: "DELETE" });
+        if (!resp.ok) {
+            console.error("Delete chat room failed:", resp.status);
+            return;
+        }
+        // If we deleted the currently selected room, switch back to default
+        if (currentChatRoom === name) {
+            currentChatRoom = "default";
+        }
+        await loadChatRooms();
+        renderChatRoomList();
+    } catch (err) {
+        console.error("Delete chat room error:", err);
+    }
+}
+
+/* --------------------------------------------------------------------------
+   Persona Picker Modal (for adding personas to a chat room)
+   -------------------------------------------------------------------------- */
+
+let ppSelectedNames = []; // Track which personas are selected in the picker
+
+function openPersonaPicker() {
+    if (currentChatRoom === "default") return;
+
+    ppSelectedNames = [];
+    document.getElementById("persona-picker-overlay").classList.remove("hidden");
+    renderPersonaPickerList();
+}
+
+function closePersonaPicker() {
+    document.getElementById("persona-picker-overlay").classList.add("hidden");
+}
+
+function renderPersonaPickerList() {
+    const listEl = document.getElementById("pp-list");
+    listEl.innerHTML = "";
+
+    // Get personas already in this room (to pre-check them? No — show ALL personas,
+    // let user pick ones to add)
+    const alreadyInRoom = new Set(roomPersonas[currentChatRoom] || []);
+
+    if (personas.length === 0) {
+        listEl.innerHTML = '<p class="pp-empty">No personas configured.</p>';
+        return;
+    }
+
+    for (const p of personas) {
+        const item = document.createElement("div");
+        item.className = "pp-list-item";
+        item.dataset.name = p.name;
+
+        const checkbox = document.createElement("input");
+        checkbox.type = "checkbox";
+        checkbox.className = "pp-checkbox";
+        checkbox.checked = false;
+        checkbox.addEventListener("click", (e) => {
+            e.stopPropagation();
+            togglePickerSelection(p.name, checkbox.checked, e.target);
+        });
+
+        const avatar = document.createElement("div");
+        avatar.className = "pp-list-item-avatar";
+        avatar.style.backgroundColor = p.avatar_color;
+        avatar.textContent = p.name.charAt(0).toUpperCase();
+
+        const info = document.createElement("div");
+        info.className = "pp-list-item-info";
+
+        const nameEl = document.createElement("div");
+        nameEl.className = "pp-list-item-name";
+        nameEl.textContent = p.name;
+
+        const descEl = document.createElement("div");
+        descEl.className = "pp-list-item-desc";
+        descEl.textContent = alreadyInRoom.has(p.name) ? p.description + " (already in room)" : p.description || "";
+
+        info.appendChild(nameEl);
+        info.appendChild(descEl);
+
+        item.appendChild(checkbox);
+        item.appendChild(avatar);
+        item.appendChild(info);
+
+        // Clicking the row toggles the checkbox
+        item.addEventListener("click", () => {
+            const isChecked = !checkbox.checked;
+            checkbox.checked = isChecked;
+            togglePickerSelection(p.name, isChecked, item);
+        });
+
+        listEl.appendChild(item);
+    }
+}
+
+function togglePickerSelection(name, isSelected, itemEl) {
+    if (isSelected) {
+        ppSelectedNames.push(name);
+        if (itemEl) itemEl.classList.add("selected");
+    } else {
+        ppSelectedNames = ppSelectedNames.filter(n => n !== name);
+        if (itemEl) itemEl.classList.remove("selected");
+    }
+
+}
+
+async function addSelectedPersonasToRoom() {
+    if (ppSelectedNames.length === 0 || currentChatRoom === "default") return;
+
+    try {
+        const resp = await fetch(
+            `/api/chatrooms/${encodeURIComponent(currentChatRoom)}/personas`,
+            {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ persona_names: ppSelectedNames }),
+            }
+        );
+
+        if (!resp.ok) {
+            const err = await resp.json().catch(() => ({}));
+            console.error("Failed to add personas to room:", err.detail);
+            return;
+        }
+
+        closePersonaPicker();
+        // Reload to refresh the persona list
+        await loadChatRooms();
+    } catch (err) {
+        console.error("Add personas to room error:", err);
+    }
+}
+
+/* ==========================================================================
+    Settings Modal
+    ========================================================================== */
 
 const settingsOverlay   = document.getElementById("settings-overlay");
 const settingsForm      = document.getElementById("settings-form");

--- a/static/app.js
+++ b/static/app.js
@@ -1510,7 +1510,7 @@ function renderPersonaPickerList() {
 
         const descEl = document.createElement("div");
         descEl.className = "pp-list-item-desc";
-        descEl.textContent = alreadyInRoom.has(p.name) ? p.description + " (already in room)" : p.description || "";
+        descEl.textContent = alreadyInRoom.has(p.name) ? (p.description || "") + " (already in room)" : (p.description || "");
 
         info.appendChild(nameEl);
         info.appendChild(descEl);

--- a/static/style.css
+++ b/static/style.css
@@ -163,8 +163,8 @@ html, body {
 }
 
 /* --------------------------------------------------------------------------
-   Sidebar
-   -------------------------------------------------------------------------- */
+    Sidebar
+    -------------------------------------------------------------------------- */
 #sidebar {
     width: var(--sidebar-width);
     min-width: var(--sidebar-width);
@@ -183,6 +183,74 @@ html, body {
     color: var(--text-muted);
     letter-spacing: 1px;
     margin-top: 8px;
+}
+
+/* Chat room selector dropdown */
+#chat-room-selector {
+    margin-bottom: 4px;
+}
+
+#chat-room-dropdown {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 6px 8px;
+    font-size: 0.85rem;
+    width: 100%;
+    cursor: pointer;
+    outline: none;
+    transition: border-color 0.15s;
+}
+
+#chat-room-dropdown:focus {
+    border-color: var(--accent);
+}
+
+/* "Add persona" button in sidebar */
+.btn-add-persona {
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+    border: 1px dashed var(--border-color);
+    border-radius: 6px;
+    padding: 6px 10px;
+    font-size: 0.8rem;
+    cursor: pointer;
+    width: 100%;
+    text-align: center;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.btn-add-persona:hover {
+    background: var(--accent);
+    border-color: var(--accent);
+    border-style: solid;
+    color: #fff;
+}
+
+.btn-add-persona.hidden {
+    display: none;
+}
+
+/* Remove persona "x" button on persona cards */
+.persona-remove-btn {
+    background: transparent;
+    border: none;
+    color: #e74c3c;
+    font-size: 1rem;
+    font-weight: 700;
+    cursor: pointer;
+    padding: 2px 6px;
+    border-radius: 4px;
+    line-height: 1;
+    flex-shrink: 0;
+    transition: background 0.15s, color 0.15s;
+    opacity: 0.5;
+}
+
+.persona-remove-btn:hover {
+    background: rgba(231, 76, 60, 0.2);
+    opacity: 1;
 }
 
 /* Who-chooser */
@@ -1019,4 +1087,151 @@ html, body {
 
 .settings-body input[type="number"] {
     -moz-appearance: textfield;
+}
+
+/* ==========================================================================
+   Chat Rooms Editor Modal
+   ========================================================================== */
+
+.cr-list {
+    overflow-y: auto;
+    padding: 12px 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-height: 60px;
+    max-height: 50vh;
+}
+
+.cr-list-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    border-radius: 8px;
+    border: 1px solid var(--border-color);
+    background: var(--bg-primary);
+}
+
+.cr-list-item-name {
+    flex: 1;
+    font-weight: 600;
+    font-size: 0.9rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.cr-list-item-count {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    flex-shrink: 0;
+}
+
+.cr-list-item-delete {
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 4px;
+    transition: color 0.15s, background 0.15s;
+    flex-shrink: 0;
+}
+
+.cr-list-item-delete:hover {
+    color: #e74c3c;
+    background: rgba(231, 76, 60, 0.15);
+}
+
+.cr-empty {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    text-align: center;
+    padding: 24px 0;
+}
+
+/* ==========================================================================
+   Persona Picker Modal (for adding to chat rooms)
+   ========================================================================== */
+
+.pp-list {
+    overflow-y: auto;
+    padding: 12px 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-height: 60px;
+    max-height: 50vh;
+}
+
+.pp-list-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 10px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background 0.15s;
+    border: 1px solid transparent;
+}
+
+.pp-list-item:hover {
+    background: var(--bg-tertiary);
+}
+
+.pp-list-item.selected {
+    background: var(--bg-tertiary);
+    border-color: var(--accent);
+}
+
+.pp-list-item-avatar {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 0.8rem;
+    color: #fff;
+    flex-shrink: 0;
+}
+
+.pp-list-item-info {
+    flex: 1;
+    min-width: 0;
+}
+
+.pp-list-item-name {
+    font-weight: 600;
+    font-size: 0.85rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.pp-list-item-desc {
+    font-size: 0.72rem;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* Custom checkbox for persona picker */
+.pp-checkbox {
+    accent-color: var(--accent);
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+    cursor: pointer;
+}
+
+.pp-empty {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    text-align: center;
+    padding: 24px 0;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,6 +20,7 @@
                     <option value="blues">Blues</option>
                 </select>
                 <button id="btn-persona-editor" title="Open persona editor">&#9998; Personas</button>
+                <button id="btn-chat-rooms" title="Manage chat rooms">&#127970; Chat Rooms</button>
                 <button id="btn-settings" title="Open settings">&#9881; Settings</button>
                 <button id="btn-new-chat" title="Start a new chat">New Chat</button>
                 <button id="btn-tts-toggle" title="Toggle TTS playback" class="icon-btn">
@@ -31,6 +32,14 @@
         <div id="main-layout">
             <!-- Left sidebar -->
             <aside id="sidebar">
+                <!-- Chat room selector -->
+                <div id="chat-room-selector">
+                    <h3>Chat Room</h3>
+                    <select id="chat-room-dropdown" title="Choose a chat room">
+                        <!-- Populated by JS -->
+                    </select>
+                </div>
+
                 <h3>Who should answer?</h3>
                 <div id="who-chooser">
                     <label class="chooser-option">
@@ -48,6 +57,7 @@
                 </div>
 
                 <h3>Personas</h3>
+                <button id="btn-add-persona" class="btn-add-persona hidden" title="Add personas to this chat room">+ Add Persona</button>
                 <div id="persona-list">
                     <!-- Populated by JS -->
                 </div>
@@ -156,6 +166,67 @@
             <div class="form-actions">
                 <button id="pe-confirm-cancel" class="btn-secondary">Cancel</button>
                 <button id="pe-confirm-delete" class="btn-danger">Delete</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Chat Rooms Editor Modal -->
+    <div id="chatrooms-overlay" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="chatrooms-title">
+        <div class="modal-box modal-box-sm">
+            <div class="modal-header">
+                <h2 id="chatrooms-title">Chat Rooms</h2>
+                <div class="modal-header-actions">
+                    <button id="cr-btn-new" class="btn-accent" title="Create new chat room">&#43; New Room</button>
+                    <button id="cr-btn-close" class="btn-icon-close" title="Close">&#10005;</button>
+                </div>
+            </div>
+            <div id="cr-form-error" class="pe-form-error hidden"></div>
+            <!-- New room form (initially hidden) -->
+            <div id="cr-new-form" class="hidden">
+                <div class="form-row" style="padding: 12px 20px;">
+                    <label for="cr-name-input">Room Name <span class="required">*</span></label>
+                    <input id="cr-name-input" type="text" maxlength="20" placeholder="Max 20 chars">
+                    <span class="field-hint">20 chars max, must be unique (not 'default')</span>
+                </div>
+                <div class="form-actions">
+                    <button type="button" id="cr-new-cancel" class="btn-secondary">Cancel</button>
+                    <button type="button" id="cr-new-save" class="btn-accent">Create</button>
+                </div>
+            </div>
+            <!-- Room list -->
+            <div id="cr-list" class="cr-list">
+                <!-- Populated by JS -->
+            </div>
+        </div>
+    </div>
+
+    <!-- Chat Room delete confirmation modal -->
+    <div id="cr-confirm-overlay" class="modal-overlay hidden" role="dialog" aria-modal="true">
+        <div class="modal-box modal-box-sm">
+            <div class="modal-header">
+                <h2>Delete Chat Room</h2>
+            </div>
+            <p id="cr-confirm-msg" class="pe-confirm-msg"></p>
+            <div class="form-actions">
+                <button id="cr-confirm-cancel" class="btn-secondary">Cancel</button>
+                <button id="cr-confirm-delete" class="btn-danger">Delete</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Persona Picker Modal (for adding personas to a chat room) -->
+    <div id="persona-picker-overlay" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="persona-picker-title">
+        <div class="modal-box modal-box-sm">
+            <div class="modal-header">
+                <h2 id="persona-picker-title">Add Personas</h2>
+                <button id="pp-btn-close" class="btn-icon-close" title="Close">&#10005;</button>
+            </div>
+            <div id="pp-list" class="pp-list">
+                <!-- Populated by JS -->
+            </div>
+            <div class="form-actions">
+                <button type="button" id="pp-btn-cancel" class="btn-secondary">Cancel</button>
+                <button type="button" id="pp-btn-add" class="btn-accent">Add Selected</button>
             </div>
         </div>
     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -201,10 +201,10 @@
     </div>
 
     <!-- Chat Room delete confirmation modal -->
-    <div id="cr-confirm-overlay" class="modal-overlay hidden" role="dialog" aria-modal="true">
+    <div id="cr-confirm-overlay" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="cr-confirm-title" aria-describedby="cr-confirm-msg">
         <div class="modal-box modal-box-sm">
             <div class="modal-header">
-                <h2>Delete Chat Room</h2>
+                <h2 id="cr-confirm-title">Delete Chat Room</h2>
             </div>
             <p id="cr-confirm-msg" class="pe-confirm-msg"></p>
             <div class="form-actions">


### PR DESCRIPTION
This PR addresses issue #18 by introducing configurable chat rooms. Personas can be assigned to or removed from chat rooms. An implicit "default" chat room always exists and always contains all configured personas. 

Controls have been added to the left panel to switch between chat rooms, and to add/remove personas from the current chat room (except for the "default" chat room, which always contains all configured personas).

A new "Chat Rooms" control has been added to the top right to allow for creation or deletion of chat rooms. The "default" chat room cannot be edited or deleted.

There is currently no chat persistence - switching chat rooms clears the main chat panel. But now we're set up for a future ticket to introduce per-chat-room persistence.