### PR TITLE
Issue #28 - mentioning a persona causes them to answer next

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@ The "Who should answer?" chooser in the UI offers the following options:
 - **Surprise me** - each prompt causes a randomly-selected persona in the current room to answer.
 - **Selected persona** - the highlighted persona in the persona list will answer next.
 
-Note that if `persona\_name\_mentions` is `true` in `settings.yaml`, mentioning a specific persona in your prompt will override
+Note that if `persona_name_mentions` is `true` in `settings.yaml`, mentioning a specific persona in your prompt will override
 the above settings and force that persona to answer you. For example, prompting "What do you think, Alex?" will automatically
 switch "Who should answer?" to "Selected persona", and make Alex the selected persona, before proceeding with the chat flow.
-If you don't like this feature, you can set `persona\_name\_mentions` to `false` and restart the application. (There is currently
+If you don't like this feature, you can set `persona_name_mentions` to `false` and restart the application. (There is currently
 no UI control over this setting - it has to be hand-edited in `settings.yaml` and is only read once on startup).
 
 ## In-App Persona Editor

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ stt:
   enabled: true
   base_url: http://localhost:8181
   timeout: 30
+
+general:
+  persona_name_mentions: true
 ```
 
 The STT `base_url` should point to an OpenAI-compatible server. The app sends audio
@@ -112,6 +115,19 @@ personas:
 | `language` | Two-letter language code describing the reference audio (defaults to `en`) |
 
 **TTS support**: Both `reference_audio` and `reference_audio_transcript` must be set for a persona to have TTS capability.
+
+#### Who answers next?
+
+The "Who should answer?" chooser in the UI offers the following options:
+- **LLM decides** - based on your prompt, and the personas currently in the room, the LLM will decide who is best suited to answer.
+- **Surprise me** - each prompt causes a randomly-selected persona in the current room to answer.
+- **Selected persona** - the highlighted persona in the persona list will answer next.
+
+Note that if `persona\_name\_mentions` is `true` in `settings.yaml`, mentioning a specific persona in your prompt will override
+the above settings and force that persona to answer you. For example, prompting "What do you think, Alex?" will automatically
+switch "Who should answer?" to "Selected persona", and make Alex the selected persona, before proceeding with the chat flow.
+If you don't like this feature, you can set `persona\_name\_mentions` to `false` and restart the application. (There is currently
+no UI control over this setting - it has to be hand-edited in `settings.yaml` and is only read once on startup).
 
 ## In-App Persona Editor
 
@@ -208,6 +224,7 @@ If you want to hear each sentence as soon as it has been synthesized, without ha
   - Add UI for server connection settings (#23)
   - Clicking a persona now updates "Who should answer?" to "Selected persona" (#24)
   - Added configurable chat rooms for grouping personas (#18)
+  - Mentioning a persona causes them to answer next (can be disabled in settings.yaml) (#28)
 
 ## License
 

--- a/app/config.py
+++ b/app/config.py
@@ -63,10 +63,16 @@ class STTConfig(BaseModel):
         return self.enabled and bool(self.base_url)
 
 
+class GeneralConfig(BaseModel):
+    """Application-wide feature flags and preferences."""
+    persona_name_mentions: bool = True
+
+
 class AppSettings(BaseModel):
     llm: LLMSettings = LLMSettings()
     tts: TTSConfig = TTSConfig()
     stt: STTConfig = STTConfig()
+    general: GeneralConfig = GeneralConfig()
 
 
 # ---------------------------------------------------------------------------
@@ -130,6 +136,7 @@ def load_settings(path: Optional[Path] = None) -> AppSettings:
         llm=LLMSettings(**raw.get("llm", {})),
         tts=TTSConfig(**raw.get("tts", {})),
         stt=STTConfig(**raw.get("stt", {})),
+        general=GeneralConfig(**raw.get("general", {})),
     )
     return _settings_cache
 
@@ -185,6 +192,7 @@ def save_settings(config: AppSettings, path: Optional[Path] = None) -> None:
         "llm": config.llm.model_dump(exclude_none=False),
         "tts": config.tts.model_dump(exclude_none=False),
         "stt": config.stt.model_dump(exclude_none=False),
+        "general": config.general.model_dump(exclude_none=False),
     }
     with open(target, "w") as f:
         yaml.dump(raw, f, default_flow_style=False, allow_unicode=True, sort_keys=False)

--- a/app/models.py
+++ b/app/models.py
@@ -156,11 +156,17 @@ class STTSettingsRequest(BaseModel):
     timeout: float = Field(..., ge=5, le=300)
 
 
+class GeneralSettingsRequest(BaseModel):
+    """General configuration from the settings editor."""
+    persona_name_mentions: bool = True
+
+
 class SettingsUpdateRequest(BaseModel):
     """Full settings payload from the frontend settings editor."""
     llm: LLMSettingsRequest
     tts: TTSSettingsRequest
     stt: STTSettingsRequest
+    general: GeneralSettingsRequest = GeneralSettingsRequest()
 
 
 class LLMSettingsResponse(BaseModel):
@@ -189,11 +195,17 @@ class STTSettingsResponse(BaseModel):
     timeout: float
 
 
+class GeneralSettingsResponse(BaseModel):
+    """General configuration for the frontend."""
+    persona_name_mentions: bool
+
+
 class SettingsResponse(BaseModel):
     """Full settings payload returned to the frontend."""
     llm: LLMSettingsResponse
     tts: TTSSettingsResponse
     stt: STTSettingsResponse
+    general: GeneralSettingsResponse
 
 
 # ---------------------------------------------------------------------------

--- a/app/routers/settings.py
+++ b/app/routers/settings.py
@@ -5,8 +5,9 @@ import logging
 from fastapi import APIRouter
 
 from app import config as app_config
-from app.config import AppSettings, LLMSettings, STTConfig, TTSConfig
+from app.config import AppSettings, GeneralConfig, LLMSettings, STTConfig, TTSConfig
 from app.models import (
+    GeneralSettingsResponse,
     LLMSettingsResponse,
     SettingsResponse,
     SettingsUpdateRequest,
@@ -40,6 +41,9 @@ def _to_response(cfg: AppSettings) -> SettingsResponse:
             enabled=cfg.stt.enabled,
             base_url=cfg.stt.base_url,
             timeout=cfg.stt.timeout,
+        ),
+        general=GeneralSettingsResponse(
+            persona_name_mentions=cfg.general.persona_name_mentions,
         ),
     )
 
@@ -82,6 +86,9 @@ def update_settings(req: SettingsUpdateRequest):
             enabled=req.stt.enabled,
             base_url=stt_base,
             timeout=req.stt.timeout,
+        ),
+        general=GeneralConfig(
+            persona_name_mentions=req.general.persona_name_mentions,
         ),
     )
 

--- a/settings.yaml
+++ b/settings.yaml
@@ -17,3 +17,6 @@ stt:
   enabled: true
   base_url: http://saturn-lm:8181
   timeout: 30
+
+general:
+  persona_name_mentions: true

--- a/static/app.js
+++ b/static/app.js
@@ -11,6 +11,7 @@
 
 let personas = [];
 let selectedPersona = null;   // The persona selected in the sidebar
+let personaNameMentionsEnabled = true;  // From settings.general.persona_name_mentions
 let ttsEnabled = false;        // Whether TTS playback is toggled on
 let ttsAvailable = false;      // Whether the TTS server is reachable
 let ttsStreaming = false;       // Whether streaming (sentence-by-sentence) TTS is enabled
@@ -70,9 +71,27 @@ async function init() {
     await loadPersonas(); // Also loads chat rooms internally
     await checkTTSHealth();
     await checkSTTHealth();
+    await loadGeneralSettings();
     setupEventListeners();
     setupChatRoomEventListeners();
     showEmptyState();
+}
+
+/**
+ * Fetch general settings from the server. Currently only used to gate
+ * the persona-name-mention detection feature.
+ */
+async function loadGeneralSettings() {
+    try {
+        const resp = await fetch("/api/settings");
+        if (!resp.ok) return;
+        const data = await resp.json();
+        if (data.general != null) {
+            personaNameMentionsEnabled = data.general.persona_name_mentions;
+        }
+    } catch (err) {
+        console.warn("Failed to load general settings, using defaults:", err);
+    }
 }
 
 async function loadPersonas() {
@@ -378,6 +397,27 @@ function showEmptyState() {
     `;
 }
 
+/**
+ * Detect if the user mentioned any persona from the current room by name.
+ * Uses case-insensitive word-boundary matching to avoid partial matches
+ * (e.g., "Sam" won't trigger "Samuel"). Returns the first matching persona
+ * name, or null if none found.
+ */
+function detectMentionedPersona(text, roomPersonaNames) {
+    for (const name of roomPersonaNames) {
+        // Escape regex special characters in the name
+        const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        // For multi-word names like "Dr. Smith", allow flexible whitespace
+        const flexible = escaped.split(/\s+/).join("\\s+");
+        const regex = new RegExp(`\\b${flexible}\\b`, "i");
+
+        if (regex.test(text)) {
+            return name;
+        }
+    }
+    return null;
+}
+
 function getWhoAnswers() {
     const chosen = document.querySelector('input[name="who_answers"]:checked').value;
     if (chosen === "selected") {
@@ -395,6 +435,23 @@ async function sendMessage() {
     if (roomPersonaNames.length === 0) {
         appendErrorBubble("No one is here.");
         return;
+    }
+
+    // Auto-select a persona if the user mentioned one by name in their message.
+    // This runs before getWhoAnswers() so the "Selected persona" radio is
+    // already checked by the time we determine who should respond.
+    // Feature can be disabled via settings.yaml: general.persona_name_mentions
+    if (personaNameMentionsEnabled) {
+        const mentioned = detectMentionedPersona(text, roomPersonaNames);
+        if (mentioned) {
+            selectedPersona = mentioned;
+            highlightSelectedPersona();
+            const selectedRadio = document.querySelector('input[name="who_answers"][value="selected"]');
+            if (selectedRadio) {
+                selectedRadio.checked = true;
+                selectedRadio.dispatchEvent(new Event("change", { bubbles: true }));
+            }
+        }
     }
 
     // Clear empty state if present
@@ -1704,6 +1761,11 @@ function collectSettingsFromForm() {
             max_tokens: parseInt(sfLlmMaxTokens.value, 10),
             temperature: parseFloat(sfLlmTemperature.value),
         },
+        // No UI for general settings yet; preserve current values so they
+        // survive a settings save round-trip.
+        general: {
+            persona_name_mentions: personaNameMentionsEnabled,
+        },
         tts: {
             enabled: sfTtsEnabled.checked,
             base_url: sfTtsBaseUrl.value.trim(),
@@ -1783,6 +1845,10 @@ async function submitSettings(e) {
 
         // Update in-memory TTS state based on new settings
         ttsStreaming = data.tts.streaming;
+        // Update in-memory general settings
+        if (data.general != null) {
+            personaNameMentionsEnabled = data.general.persona_name_mentions;
+        }
         // Re-check service health to update UI availability after settings change
         await checkTTSHealth();
         await checkSTTHealth();


### PR DESCRIPTION
This PR addresses issue #28 by adding a basic name-detection mechanism at the start of the chat flow, such that if the user mentions a persona by name (for example, "What do you think, Alex?"), the current "Who should answer?" state is overridden to force Alex to answer the prompt. 

Only personas that are in the current chat room are considered. Mentioning a persona that is not in the current room will not summon them.

The feature can be disabled in `settings.yaml` if the user doesn't like it. It is enabled by default. There is currently no UI mechanism to change this option - it has to be hand-edited in `settings.yaml` and is only read once on startup.