### PR TITLE
Issue 4 chat persistence

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,27 +13,48 @@ There is no test suite. Manual testing is done by running the app and using the 
 
 **Backend**: FastAPI app in `app/`. Config is loaded from `settings.yaml` (LLM, TTS, and STT endpoints), `personas.yaml` (persona definitions), and `chatrooms.yaml` (chat room groupings) at startup. All three are cached in module-level globals in `app/config.py` — always use `get_settings()` / `get_personas()` / `get_chatrooms()` rather than calling `load_*()` directly in request handlers.
 
-**Session**: Single global `session` singleton in `app/session.py` (`SessionManager`). This is intentional — the app is single-user. History is a list of `ChatMessage` objects. `session.build_llm_messages()` constructs the per-call LLM payload, interleaving multi-persona history by prefixing other personas' turns with `[Name]: <text>` so the responding LLM understands the group chat context.
+**Session**: Single global `session` singleton in `app/session.py` (`SessionManager`). This is intentional — the app is single-user. History is a list of `ChatMessage` objects. `session.build_llm_messages()` constructs the per-call LLM payload, interleaving multi-persona history by prefixing other personas' turns with `[Name]: <text>` so the responding LLM understands the group chat context. The session tracks `current_room` and persists messages to disk automatically via `app/persistence.py`.
+
+**Persistence**: Per-room JSON + audio files under `chatrooms/<room>/`. `app/persistence.py` is framework-agnostic and handles `persist_message()`, `persist_audio()`, `load_history()`, and `clear_room()`. `app/routers/persistence.py` provides the audio upload and playback serving endpoints. Created lazily on first write.
 
 **Chat flow** (`app/routers/chat.py`):
-1. `POST /api/chat` resolves `who_answers` → persona name via `_pick_persona()`
-2. `_pick_persona()` supports three modes: `"router"` (ask the LLM to pick), `"random"`, or an explicit persona name
-3. Responses stream as SSE with typed JSON events: `start`, `token`, `done`, `error`, `complete`
+1. `POST /api/chat` accepts `chat_room` (which room to persist to) and `message_id` (frontend-generated UUID for audio association)
+2. Resolves `who_answers` → persona name via `_pick_persona()`
+3. `_pick_persona()` supports three modes: `"router"` (ask the LLM to pick), `"random"`, or an explicit persona name
+4. Responses stream as SSE with typed JSON events: `start`, `token`, `done`, `error`, `complete`
+5. The `done` event returns `message_id` (server-generated UUID for the assistant message)
 
 **Frontend** (`static/`): Vanilla JS single-page app split across multiple modules. Each module is a plain script (no bundler) — they communicate through shared globals defined in `state.js`.
 
 | File | Responsibility |
 |------|---------------|
-| `state.js` | Shared globals (personas, session state, TTS/STT flags, audio queue, chat room state) |
-| `app.js` | App bootstrap, SSE stream handling, message sending |
-| `chat.js` | Chat message rendering and scroll behavior |
+| `state.js` | Shared globals (personas, session state, chat room state, TTS/STT flags, audio queue, message IDs) |
+| `app.js` | Bootstrap, health checks, event listener setup, session management |
+| `chat.js` | Message rendering, SSE stream handling, sending messages, persisted history rendering, audio playback buttons |
+| `persistence.js` | History loading, audio upload helpers, audio URL generation |
 | `persona.js` | Persona sidebar rendering and persona editor modal (CRUD) |
-| `chatrooms.js` | Chat room dropdown, room filtering, room editor modal, persona picker |
+| `chatrooms.js` | Chat room dropdown, room filtering, room editor modal, persona picker, room switching with history load |
 | `settings.js` | Settings modal (LLM, TTS, STT, general config) |
-| `tts.js` | TTS synthesis, audio queue, Web Audio API playback |
-| `stt.js` | Microphone recording, STT proxy, transcript insertion |
+| `tts.js` | TTS synthesis, audio queues, Web Audio API playback, audio persistence |
+| `stt.js` | Microphone recording, STT proxy, transcript insertion, audio persistence |
 | `theme.js` | Dark/light theme toggle |
 | `utils.js` | Shared utility helpers |
+
+## Chat Persistence
+
+Every message is persisted to disk automatically — no configuration toggle needed.
+
+- **Location**: `chatrooms/<room_name>/history.json` + audio files alongside it.
+- **Format**: JSON with `datetime` (ISO-8601) and `messages` array. Each message has `id` (UUID), `sender` ("USER" or persona name), `text`, and `audio` (array of filenames).
+- **Audio files**: Named `<message_uuid>_<index>.<ext>` (e.g. `d4ee3044_1.wav`). Extension derived from MIME type, falls back to `.bin`.
+- **Room switching**: `GET /api/session/load-room/<room_name>` loads persisted history and populates the in-memory session.
+- **New Chat**: `POST /api/session/new` clears both in-memory history and deletes all files in the room's persistence directory.
+- **Audio upload**: `POST /api/persist/audio?room=<room>` accepts base64 audio and appends it to the message's audio list.
+- **Audio playback**: `GET /api/persist/audio/<room>/<filename>` serves persisted audio files.
+
+The `SessionManager.add_user_message()` and `add_assistant_message()` methods take a `message_id` parameter and call `persistence.persist_message()` automatically.
+
+Both TTS and STT capture audio and persist it to the current room via `persistence.js`. TTS audio is associated with the assistant message ID from the `done` event. STT audio is associated with the user message ID generated before `sendMessage()`.
 
 ## API Endpoints
 
@@ -53,10 +74,13 @@ There is no test suite. Manual testing is done by running the app and using the 
 | `DELETE` | `/api/chatrooms/{name}` | Delete a chat room |
 | `PUT` | `/api/chatrooms/{name}/personas` | Add personas to a room |
 | `DELETE` | `/api/chatrooms/{name}/personas/{persona_name}` | Remove a persona from a room |
-| `GET` | `/api/session` | Get current session state (history + active personas) |
-| `POST` | `/api/session/new` | Clear history and reset session |
+| `GET` | `/api/session` | Get current session state (history + active personas + current room) |
+| `POST` | `/api/session/new` | Clear history and reset session (also clears persisted files) |
 | `POST` | `/api/session/personas` | Update active personas for the session |
+| `GET` | `/api/session/load-room/{room_name}` | Load persisted history for a room into the active session |
 | `POST` | `/api/chat` | Send a message; returns SSE stream |
+| `POST` | `/api/persist/audio?room=<room>` | Upload base64 audio for a persisted message |
+| `GET` | `/api/persist/audio/{room}/{filename}` | Serve a persisted audio file for playback |
 | `GET` | `/api/tts/health` | TTS availability status |
 | `POST` | `/api/tts` | Proxy text → TTS `/synthesize`; returns `{audio_base64, sample_rate}` |
 | `GET` | `/api/stt/health` | STT availability status |
@@ -64,24 +88,25 @@ There is no test suite. Manual testing is done by running the app and using the 
 | `GET` | `/api/settings` | Get current settings |
 | `PUT` | `/api/settings` | Update and persist settings to `settings.yaml` |
 
-**STT flow**: The microphone button in the input bar uses `getUserMedia` + `MediaRecorder`. Click to start, click again to stop. The recorded blob is base64-encoded and POSTed to `/api/stt`, which proxies to `/v1/audio/transcriptions` at `settings.stt.base_url`. On success, the transcribed text is appended to the input box (never replaces) and `sendMessage()` is called automatically. A 5xx response disables the mic button for the session. STT is independently enabled/disabled via `settings.stt.enabled` — it has no dependency on TTS.
+**STT flow**: The microphone button in the input bar uses `getUserMedia` + `MediaRecorder`. Click to start, click again to stop. The recorded blob is base64-encoded and POSTed to `/api/stt`, which proxies to `/v1/audio/transcriptions` at `settings.stt.base_url`. On success, the transcribed text is appended to the input box (never replaces) and `sendMessage()` is called automatically. The recorded audio is also persisted to the current room via `persistence.js`. A 5xx response disables the mic button for the session. STT is independently enabled/disabled via `settings.stt.enabled` — it has no dependency on TTS.
 
-**TTS server** (`app/routers/tts.py`, `app/services/tts_client.py`): The `/api/tts` and `/api/tts/health` routes live in `app/routers/tts.py`. The client functions `synthesize()` and `check_tts_health()` are in `app/services/tts_client.py`. TTS is independently enabled/disabled via `settings.tts.enabled`. A persona is TTS-capable only when both `reference_audio` and `reference_audio_transcript` are set in `personas.yaml` (computed as a `@property` on `Persona` in `app/config.py`). TTS supports a `streaming` mode (sentence-by-sentence) controlled by `settings.tts.streaming`.
+**TTS server** (`app/routers/tts.py`, `app/services/tts_client.py`): The `/api/tts` and `/api/tts/health` routes live in `app/routers/tts.py`. The client functions `synthesize()` and `check_tts_health()` are in `app/services/tts_client.py`. TTS is independently enabled/disabled via `settings.tts.enabled`. A persona is TTS-capable only when both `reference_audio` and `reference_audio_transcript` are set in `personas.yaml` (computed as a `@property` on `Persona` in `app/config.py`). TTS supports a `streaming` mode (sentence-by-sentence) controlled by `settings.tts.streaming`. TTS audio is automatically persisted to the current room after synthesis.
 
 **STT server** (`app/routers/stt.py`, `app/services/stt_client.py`): The `/api/stt` route lives in `app/routers/stt.py`. The client function `parse_audio()` is in `app/services/stt_client.py`. STT is independently enabled/disabled via `settings.stt.enabled` and has its own `base_url` and `timeout` in `settings.yaml`. STT requires no per-persona config.
 
 **Settings API** (`app/routers/settings.py`): `GET /api/settings` returns the full `AppSettings` object. `PUT /api/settings` validates, normalizes (blank base URLs → `None`, seed `0` → `None`), and persists to `settings.yaml`. Changes take effect immediately without a restart.
 
-**Chat rooms** (`app/routers/chatrooms.py`, `app/config.py`): Chat rooms are stored in `chatrooms.yaml` and managed via `get_chatrooms()` / `save_chatrooms()`. The implicit `"default"` room always contains all personas and cannot be created, edited, or deleted. Renaming or deleting a persona cascades to all chat room assignments automatically (handled in `app/routers/personas.py`).
+**Chat rooms** (`app/routers/chatrooms.py`, `app/config.py`): Chat rooms are stored in `chatrooms.yaml` and managed via `get_chatrooms()` / `save_chatrooms()`. The implicit `"default"` room always contains all personas and cannot be created, edited, or deleted. Renaming or deleting a persona cascades to all chat room assignments automatically (handled in `app/routers/personas.py`). Switching rooms loads persisted history from disk rather than clearing the session.
 
 ## Key Conventions
 
 - **Pydantic everywhere**: all request/response shapes and config models are in `app/models.py` and `app/config.py`. Add new fields there.
-- **SSE event schema**: every event is `data: <JSON>\n\n`. The `type` field is always present. Frontend switches on it in `handleSSEEvent()` in `app.js`.
+- **SSE event schema**: every event is `data: <JSON>\n\n`. The `type` field is always present. Frontend switches on it in `handleSSEEvent()` in `chat.js`.
+- **Chat request body**: `POST /api/chat` includes `chat_room` (which room to persist to) and `message_id` (frontend-generated UUID for audio association). The `done` event returns `message_id` (server-generated UUID for the assistant message).
 - **Config hot-reload**: call `app.config.reload_all()` to force re-read all three YAML files (settings, personas, chatrooms). The `--reload` uvicorn flag handles Python file changes only; YAML changes require `reload_all()` or a restart.
 - **Persona router** uses a low-temperature (0.1) non-streaming LLM call capped at 16 tokens to pick a persona name. If the LLM returns an unrecognized name, it falls back to random.
 - **Routers** live in `app/routers/`, **external service clients** (LLM, TTS, STT) live in `app/services/`. Keep that separation.
 - **`is_active` property**: both `TTSConfig` and `STTConfig` expose an `is_active` property that returns `True` only when `enabled=True` AND `base_url` is non-empty. Use this instead of checking `enabled` alone.
 - **Persona CRUD cascades**: persona rename and delete both cascade to `chatrooms.yaml` via `_cascade_persona_rename()` and `_cascade_persona_delete()` in `app/routers/personas.py`. Keep this in sync if the persona or chatroom data model changes.
 - **General settings**: `settings.general.persona_name_mentions` controls whether the frontend prefixes assistant messages with the persona's name. It has no backend effect.
-- **No auth, no database** — by design. Don't add persistent storage or user management without revisiting the single-user assumption throughout.
+- **No auth, no database** — by design. The `chatrooms/` directory is the only persistent storage. Don't add user management without revisiting the single-user assumption throughout.

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ app/services/__pycache__/
 app/routers/__pycache__/
 personas.yaml.*
 future*.md
+chatrooms/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,32 +25,52 @@ To force a re-read of all three files, call `app.config.reload_all()`.
 ## Architecture
 
 - **Backend**: FastAPI. Entry point: `app/main.py`. Routers in `app/routers/`, external service clients in `app/services/`.
-- **Session**: Single global `session` singleton in `app/session.py`. Intentional — this is a single-user app. No auth, no database.
+- **Session**: Single global `session` singleton in `app/session.py`. Intentional — this is a single-user app. No auth, no database. Tracks `current_room` and persists messages to disk automatically.
+- **Persistence**: Per-room JSON + audio files under `chatrooms/<room>/`. Handled by `app/persistence.py` (framework-agnostic) and `app/routers/persistence.py` (audio upload/serving endpoints). Created lazily on first write.
 - **Frontend**: Vanilla JS SPA, no bundler. Modules in `static/` communicate via shared globals in `state.js`. See the table below:
 
 | File | Responsibility |
 |------|---------------|
-| `state.js` | Shared globals (personas, session state, chat room state, TTS/STT flags, audio queue) |
-| `app.js` | Bootstrap, SSE stream handling, message sending |
-| `chat.js` | Message rendering, scroll behavior |
+| `state.js` | Shared globals (personas, session state, chat room state, TTS/STT flags, audio queue, message IDs) |
+| `app.js` | Bootstrap, health checks, event listener setup, session management |
+| `chat.js` | Message rendering, SSE stream handling, sending messages, persisted history rendering, audio playback buttons |
+| `persistence.js` | History loading, audio upload helpers, audio URL generation |
 | `persona.js` | Persona sidebar + editor modal (CRUD) |
-| `chatrooms.js` | Chat room dropdown, room filtering, room editor |
+| `chatrooms.js` | Chat room dropdown, room filtering, room editor, room switching with history load |
 | `settings.js` | Settings modal (LLM/TTS/STT config) |
-| `tts.js` | TTS synthesis, audio queue, Web Audio playback |
-| `stt.js` | Microphone recording, STT proxy, transcript insertion |
+| `tts.js` | TTS synthesis, audio queues, Web Audio playback, audio persistence |
+| `stt.js` | Microphone recording, STT proxy, transcript insertion, audio persistence |
 | `theme.js` | Theme toggle |
 | `utils.js` | Shared helpers |
 
 ## Chat flow
 
 `POST /api/chat` streams SSE with typed JSON events: `start`, `token`, `done`, `error`, `complete`.
-The frontend switches on `type` in `handleSSEEvent()` in `app.js`.
+The request body includes `chat_room` (which room to persist to) and `message_id` (frontend-generated UUID for audio association).
+The `done` event returns `message_id` (server-generated UUID for the assistant message).
+The frontend switches on `type` in `handleSSEEvent()` in `chat.js`.
 
 Persona selection modes: `"router"` (LLM picks, low-temp 16-token call), `"random"`, or an explicit persona name.
+
+## Chat persistence
+
+Every message is persisted to disk automatically — no configuration toggle needed.
+
+- **Location**: `chatrooms/<room_name>/history.json` + audio files alongside it.
+- **Format**: JSON with `datetime` (ISO-8601) and `messages` array. Each message has `id` (UUID), `sender` ("USER" or persona name), `text`, and `audio` (array of filenames).
+- **Audio files**: Named `<message_uuid>_<index>.<ext>` (e.g. `d4ee3044_1.wav`). Extension derived from MIME type, falls back to `.bin`.
+- **Room switching**: `GET /api/session/load-room/<room_name>` loads persisted history and populates the in-memory session.
+- **New Chat**: `POST /api/session/new` clears both in-memory history and deletes all files in the room's persistence directory.
+- **Audio upload**: `POST /api/persist/audio?room=<room>` accepts base64 audio and appends it to the message's audio list.
+- **Audio playback**: `GET /api/persist/audio/<room>/<filename>` serves persisted audio files.
+
+The `SessionManager.add_user_message()` and `add_assistant_message()` methods take a `message_id` parameter and call `persistence.persist_message()` automatically.
 
 ## TTS and STT are independent
 
 Each has its own `enabled` + `base_url` in `settings.yaml`. Use the `is_active` property (requires both enabled AND a non-empty base_url) instead of checking `enabled` alone.
+
+Both TTS and STT capture audio and persist it to the current room via `persistence.js`. TTS audio is associated with the assistant message ID from the `done` event. STT audio is associated with the user message ID generated before `sendMessage()`.
 
 ## Persona CRUD cascades
 
@@ -59,7 +79,3 @@ Renaming or deleting a persona cascades to `chatrooms.yaml` via `_cascade_person
 ## Pydantic models
 
 All request/response shapes and config models live in `app/models.py` and `app/config.py`. Add new fields there, not inline in routers.
-
-## Chat history is in-memory only
-
-History lives in the `SessionManager` singleton. "New Chat" clears it. No persistence to disk.

--- a/README.md
+++ b/README.md
@@ -197,6 +197,25 @@ If you prefer to hear the persona's response in one clear, contiguous audio play
 
 If you want to hear each sentence as soon as it has been synthesized, without having to wait for the ENTIRE response to be synthesized, and you don't mind the occasional pause in between sentences, then enable streaming mode in configuration.
 
+## Chat persistence
+
+Each chat room persists its chat history to a dedicated subdirectory in the top-level `chatrooms` directory.
+For example, a chat room named `chit-chat` will persist to `<projectDir>/chatrooms/chit-chat`. All text and
+audio are saved there. If the history gets too long, you may overflow the context limit of the LLM. You can
+select "New Chat" at any time to clear the chat history and start over. 
+
+Each chat room persists separately! Selecting "New Chat" in the `chit-chat-1` room will not clear the
+history in the `chit-chat-2` room, and vice versa.
+
+## Replaying audio
+
+A small "replay" icon will appear underneath messages that have audio associated with them. This applies both
+to persona-generated messages that were sent to the TTS server, and also user-supplied microphone input.
+Clicking this "replay" button will replay the audio for that message. 
+
+Note: in `streaming` mode, personas will generate a separate audio file for each sentence in their message.
+A separate "replay" icon will be showed for each sentence, side-by-each.
+
 ## Notes
 
 - The TTS server is optional. If unreachable, TTS is silently disabled.
@@ -226,6 +245,8 @@ If you want to hear each sentence as soon as it has been synthesized, without ha
   - Added configurable chat rooms for grouping personas (#18)
   - Mentioning a persona causes them to answer next (can be disabled in settings.yaml) (#28)
   - Break up the `app.js` monolith for code maintainability (#29)
+  - Chat persistence (#4)
+  - Save generated audio and allow replay (#5)
 
 ## License
 

--- a/app/main.py
+++ b/app/main.py
@@ -14,7 +14,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from app import config as app_config
-from app.routers import chat, chatrooms, personas, session as session_router, settings, stt, tts
+from app.routers import chat, chatrooms, personas, persistence, session as session_router, settings, stt, tts
 from app.session import session
 
 logger = logging.getLogger(__name__)
@@ -66,6 +66,7 @@ app.include_router(chat.router)
 app.include_router(tts.router)
 app.include_router(stt.router)
 app.include_router(settings.router)
+app.include_router(persistence.router)
 
 # Jinja2 templates
 templates = Jinja2Templates(directory=str(Path(__file__).resolve().parent.parent / "templates"))

--- a/app/models.py
+++ b/app/models.py
@@ -16,6 +16,14 @@ class ChatRequest(BaseModel):
         default="router",
         description='One of "router", "random", or a persona name',
     )
+    chat_room: str = Field(
+        default="default",
+        description="The chat room this message belongs to (for persistence)",
+    )
+    message_id: Optional[str] = Field(
+        default=None,
+        description="Frontend-generated UUID for this message (for audio association)",
+    )
 
 
 class SessionPersonasRequest(BaseModel):
@@ -89,6 +97,29 @@ class SessionState(BaseModel):
     """Current session snapshot for the frontend."""
     history: List[dict] = Field(default_factory=list)
     active_personas: List[str] = Field(default_factory=list)
+    current_room: str = Field(default="default", description="The currently active chat room")
+
+
+class PersistedMessage(BaseModel):
+    """A persisted chat message loaded from disk."""
+    id: str
+    sender: str
+    text: str
+    audio: List[str] = Field(default_factory=list)
+
+
+class PersistedHistoryResponse(BaseModel):
+    """Persisted chat history for a room."""
+    room: str
+    datetime: Optional[str] = None
+    messages: List[PersistedMessage] = Field(default_factory=list)
+
+
+class AudioUploadRequest(BaseModel):
+    """Frontend uploads audio for a persisted message."""
+    message_id: str
+    audio_base64: str
+    mime_type: Optional[str] = None
 
 
 class TTSResponse(BaseModel):

--- a/app/persistence.py
+++ b/app/persistence.py
@@ -1,0 +1,187 @@
+"""Chat persistence — per-room message and audio storage on disk.
+
+Each chat room gets its own subdirectory under the top-level `chatrooms/`
+directory. A single JSON file stores all messages, and audio files are
+written alongside it using the message UUID as filename prefix.
+
+This module is intentionally framework-agnostic so it can be called from
+routers, the session manager, or tests without pulling in FastAPI deps.
+"""
+
+import base64
+import json
+import logging
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from app.models import ChatMessage
+
+logger = logging.getLogger(__name__)
+
+# Top-level persistence root — created lazily on first write.
+# app/persistence.py → .parent → app/ → .parent → project root
+_PERSISTENCE_ROOT = Path(__file__).resolve().parent.parent / "chatrooms"
+
+
+def _room_dir(room_name: str) -> Path:
+    """Return the path to a chat room's persistence subdirectory."""
+    return _PERSISTENCE_ROOT / room_name
+
+
+def _history_path(room_name: str) -> Path:
+    """Return the path to the JSON history file for a room."""
+    return _room_dir(room_name) / "history.json"
+
+
+def _audio_file_extension(mime_type: Optional[str]) -> str:
+    """Derive a file extension from a MIME type, falling back to '.bin'."""
+    if not mime_type:
+        return ".bin"
+    # "audio/webm" -> ".webm", "audio/ogg" -> ".ogg", etc.
+    ext = mime_type.split("/")[-1].split("+")[0]
+    if ext:
+        return f".{ext}"
+    return ".bin"
+
+
+def _audio_filename(message_id: str, index: int, mime_type: Optional[str] = None) -> str:
+    """Generate a deterministic audio filename from a message UUID and index."""
+    return f"{message_id}_{index}{_audio_file_extension(mime_type)}"
+
+
+# ---------------------------------------------------------------------------
+# Message persistence
+# ---------------------------------------------------------------------------
+
+def persist_message(room_name: str, message: ChatMessage, message_id: str) -> str:
+    """Append a message to the room's persisted history and write to disk.
+
+    Returns the message ID (same one passed in).
+    """
+    room = _room_dir(room_name)
+    room.mkdir(parents=True, exist_ok=True)
+    path = _history_path(room_name)
+
+    # Load existing history or start fresh
+    if path.exists():
+        with open(path) as f:
+            data: Dict[str, Any] = json.load(f)
+    else:
+        data = {"datetime": None, "messages": []}
+
+    now = datetime.now().astimezone().isoformat()
+    data["datetime"] = now
+
+    sender = "USER" if message.role == "user" else (message.persona or "unknown")
+    data["messages"].append({
+        "id": message_id,
+        "sender": sender,
+        "text": message.content,
+        "audio": [],
+    })
+
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+    logger.debug("Persisted message %s to room '%s'", message_id, room_name)
+    return message_id
+
+
+def persist_audio(
+    room_name: str,
+    message_id: str,
+    audio_base64: str,
+    mime_type: Optional[str] = None,
+) -> str:
+    """Save an audio file for a message and update its audio list in history.
+
+    Returns the filename that was written.
+    """
+    room = _room_dir(room_name)
+    room.mkdir(parents=True, exist_ok=True)
+    path = _history_path(room_name)
+
+    # Single read — determine next index and locate the target message
+    data: Dict[str, Any] = {"datetime": None, "messages": []}
+    if path.exists():
+        with open(path) as f:
+            data = json.load(f)
+
+    index = 0
+    msg_found = None
+    for msg in data.get("messages", []):
+        if msg["id"] == message_id:
+            index = len(msg.get("audio", []))
+            msg_found = msg
+            break
+
+    filename = _audio_filename(message_id, index, mime_type)
+
+    # Write the raw audio bytes
+    raw = base64.b64decode(audio_base64)
+    with open(room / filename, "wb") as f:
+        f.write(raw)
+
+    # Update the message's audio list in a single write
+    if msg_found:
+        msg_found.setdefault("audio", []).append(filename)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+    logger.debug("Persisted audio '%s' for message %s in room '%s'", filename, message_id, room_name)
+    return filename
+
+
+def load_history(room_name: str) -> List[Dict[str, Any]]:
+    """Load persisted messages for a room.
+
+    Returns a list of message dicts matching the JSON schema.
+    Returns an empty list if no history exists.
+    """
+    path = _history_path(room_name)
+    if not path.exists():
+        return []
+
+    with open(path) as f:
+        data: Dict[str, Any] = json.load(f)
+
+    return data.get("messages", [])
+
+
+def load_history_with_metadata(room_name: str) -> Dict[str, Any]:
+    """Load persisted messages and metadata for a room.
+
+    Returns a dict with "datetime" and "messages" keys.
+    Returns {"datetime": None, "messages": []} if no history exists.
+    """
+    path = _history_path(room_name)
+    if not path.exists():
+        return {"datetime": None, "messages": []}
+
+    with open(path) as f:
+        data: Dict[str, Any] = json.load(f)
+
+    return {
+        "datetime": data.get("datetime"),
+        "messages": data.get("messages", []),
+    }
+
+
+def clear_room(room_name: str) -> None:
+    """Delete all persisted files for a room.
+
+    The subdirectory itself is preserved (so it still exists for future messages).
+    """
+    room = _room_dir(room_name)
+    if not room.exists():
+        return
+
+    for item in room.iterdir():
+        if item.is_file():
+            item.unlink()
+        elif item.is_dir():
+            shutil.rmtree(item)
+
+    logger.info("Cleared persistence for room '%s'", room_name)

--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -2,12 +2,13 @@
 
 Receives a user message, decides which persona should respond (router, random,
 or explicit selection), streams tokens back via SSE, and appends the full
-response to session history.
+response to session history. Messages are persisted to disk per chat room.
 """
 
 import json
 import logging
 import random
+import uuid
 from typing import AsyncIterator
 
 from fastapi import APIRouter
@@ -104,6 +105,9 @@ async def _pick_persona(who_answers: str, user_message: str) -> str:
 
 async def _chat_stream(req: ChatRequest) -> AsyncIterator[str]:
     """Generator that yields SSE-formatted JSON lines."""
+    # Switch to the requested chat room for persistence
+    session.set_current_room(req.chat_room)
+
     persona_name = await _pick_persona(req.who_answers, req.message)
     config = get_personas()
     persona = next((p for p in config.personas if p.name == persona_name), None)
@@ -111,8 +115,11 @@ async def _chat_stream(req: ChatRequest) -> AsyncIterator[str]:
         yield f'data: {json.dumps({"type": "error", "message": f"Persona {persona_name} not found"})}\n\n'
         return
 
-    # Add user message to history
-    session.add_user_message(req.message)
+    # Use frontend-provided message ID or generate one
+    user_message_id = req.message_id or str(uuid.uuid4())
+
+    # Add user message to history (persisted automatically)
+    session.add_user_message(req.message, user_message_id)
 
     # Build LLM messages with the responding persona's system prompt
     messages = session.build_llm_messages(
@@ -120,12 +127,8 @@ async def _chat_stream(req: ChatRequest) -> AsyncIterator[str]:
         responding_persona=persona_name,
     )
 
-    # Append the user's message to the messages list (it's the latest)
-    # Actually, build_llm_messages already includes all history including the
-    # user message we just added. So we're good.
-
-    # Emit start event
-    yield f'data: {json.dumps({"type": "start", "persona": persona_name})}\n\n'
+    # Emit start event — include the user's message_id so frontend can track it
+    yield f'data: {json.dumps({"type": "start", "persona": persona_name, "user_message_id": user_message_id})}\n\n'
 
     # Stream tokens
     full_text = ""
@@ -138,11 +141,14 @@ async def _chat_stream(req: ChatRequest) -> AsyncIterator[str]:
         yield f'data: {json.dumps({"type": "error", "message": str(exc)})}\n\n'
         return
 
-    # Append full response to session history
-    session.add_assistant_message(full_text, persona_name)
+    # Generate assistant message ID
+    assistant_message_id = str(uuid.uuid4())
 
-    # Emit done and complete events
-    yield f'data: {json.dumps({"type": "done", "persona": persona_name, "text": full_text})}\n\n'
+    # Append full response to session history (persisted automatically)
+    session.add_assistant_message(full_text, persona_name, assistant_message_id)
+
+    # Emit done and complete events — include assistant message_id
+    yield f'data: {json.dumps({"type": "done", "persona": persona_name, "text": full_text, "message_id": assistant_message_id})}\n\n'
     yield f'data: {json.dumps({"type": "complete"})}\n\n'
 
 

--- a/app/routers/chatrooms.py
+++ b/app/routers/chatrooms.py
@@ -68,8 +68,11 @@ def create_chatroom(req: ChatRoomCreateRequest):
             status_code=409,
             detail=f"'{DEFAULT_ROOM}' is a reserved chat room name and cannot be created.",
         )
-    if not re.match(r'^[a-zA-Z0-9 _-]+$', name):
-        raise HTTPException(status_code=422, detail="Room name contains invalid characters.")
+    if not re.match(r'^[a-zA-Z0-9_-]+$', name):
+        raise HTTPException(
+            status_code=422,
+            detail="Room name may only contain letters, numbers, hyphens, and underscores.",
+        )
 
     config = get_chatrooms()
     if any(r.name.lower() == name.lower() for r in config.chat_rooms):

--- a/app/routers/persistence.py
+++ b/app/routers/persistence.py
@@ -1,0 +1,47 @@
+"""Chat persistence router — audio upload and audio file serving.
+
+Provides endpoints for the frontend to upload recorded/synthesized audio
+files and retrieve them for playback.
+"""
+
+import logging
+
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import FileResponse
+
+from app.models import AudioUploadRequest
+from app.persistence import _PERSISTENCE_ROOT, persist_audio
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/persist", tags=["persistence"])
+
+
+@router.post("/audio")
+def upload_audio(
+    req: AudioUploadRequest,
+    room: str = Query(..., description="The chat room this audio belongs to"),
+):
+    """Upload an audio file for a persisted message.
+
+    The frontend calls this after capturing STT recordings or TTS output.
+    The audio is saved to the chat room's persistence directory and the
+    message's audio list is updated in history.json.
+    """
+    try:
+        filename = persist_audio(room, req.message_id, req.audio_base64, req.mime_type)
+        return {"status": "saved", "filename": filename}
+    except Exception as exc:
+        logger.error("Failed to persist audio for message %s: %s", req.message_id, exc)
+        raise HTTPException(status_code=500, detail=f"Failed to save audio: {exc}")
+
+
+@router.get("/audio/{room_name}/{filename}")
+def serve_audio(room_name: str, filename: str):
+    """Serve a persisted audio file for playback.
+
+    The frontend uses this to replay audio from previous messages.
+    """
+    audio_path = _PERSISTENCE_ROOT / room_name / filename
+    if not audio_path.exists() or not audio_path.is_file():
+        raise HTTPException(status_code=404, detail="Audio file not found.")
+    return FileResponse(audio_path, media_type="audio/*")

--- a/app/routers/personas.py
+++ b/app/routers/personas.py
@@ -94,6 +94,11 @@ def create_persona(req: PersonaCreateRequest):
     lower_name = req.name.strip().lower()
     if not lower_name:
         raise HTTPException(status_code=422, detail="Name may not be blank")
+    if lower_name == "user":
+        raise HTTPException(
+            status_code=422,
+            detail="'user' is a reserved persona name and cannot be used.",
+        )
     if any(p.name.lower() == lower_name for p in config.personas):
         raise HTTPException(status_code=409, detail=f"A persona named '{req.name}' already exists")
 
@@ -133,6 +138,11 @@ def update_persona(name: str, req: PersonaUpdateRequest):
     new_name = req.name.strip()
     if not new_name:
         raise HTTPException(status_code=422, detail="Name may not be blank")
+    if new_name.lower() == "user":
+        raise HTTPException(
+            status_code=422,
+            detail="'user' is a reserved persona name and cannot be used.",
+        )
 
     if new_name.lower() != name.lower():
         if any(p.name.lower() == new_name.lower() for p in config.personas if p.name != name):

--- a/app/routers/session.py
+++ b/app/routers/session.py
@@ -1,11 +1,13 @@
 """Session router — inspect, reset, and configure the active session."""
 
 import logging
+import uuid
 
 from fastapi import APIRouter
 
 from app.config import get_personas
-from app.models import SessionPersonasRequest, SessionState
+from app.models import SessionPersonasRequest, SessionState, PersistedHistoryResponse, PersistedMessage
+from app.persistence import load_history_with_metadata
 from app.session import session
 
 logger = logging.getLogger(__name__)
@@ -18,6 +20,7 @@ def get_session():
     return SessionState(
         history=session.get_history_dicts(),
         active_personas=session.active_personas,
+        current_room=session.current_room,
     )
 
 
@@ -45,3 +48,19 @@ def update_active_personas(req: SessionPersonasRequest):
 
     session.set_active_personas(list(requested & valid_names))
     return {"status": "updated", "active_personas": session.active_personas}
+
+
+@router.get("/load-room/{room_name}")
+def load_room(room_name: str):
+    """Load persisted chat history for a room into the active session.
+
+    Used when switching chat rooms. Clears any existing in-memory history
+    and populates from the room's persisted data.
+    """
+    session.load_room(room_name)
+    metadata = load_history_with_metadata(room_name)
+    return PersistedHistoryResponse(
+        room=room_name,
+        datetime=metadata["datetime"],
+        messages=[PersistedMessage(**m) for m in metadata["messages"]],
+    )

--- a/app/session.py
+++ b/app/session.py
@@ -1,12 +1,15 @@
-"""In-memory session state.
+"""In-memory session state with disk persistence.
 
 Single-user app means one global session object.
 History is a simple list of dicts: {"role": "user"|"assistant", "content": str, "persona": str|None}.
+
+Messages are automatically persisted to disk per chat room as they arrive.
 """
 
 from typing import Dict, List, Optional
 
 from app.models import ChatMessage
+from app import persistence
 
 
 class SessionManager:
@@ -15,13 +18,46 @@ class SessionManager:
     def __init__(self):
         self._history: List[ChatMessage] = []
         self._active_personas: List[str] = []
+        self._current_room: str = "default"
 
     # -- Public API ----------------------------------------------------------
 
+    @property
+    def current_room(self) -> str:
+        return self._current_room
+
+    def set_current_room(self, room_name: str):
+        """Switch the active chat room.
+
+        Messages are persisted individually as they arrive, so no bulk
+        flush is needed here. Just updates the room tracker.
+        """
+        if room_name == self._current_room:
+            return
+        self._current_room = room_name
+
     def reset(self):
-        """Wipe history and active personas. Called on 'New Chat'."""
+        """Wipe history, clear persistence for current room, and reset personas.
+        Called on 'New Chat'.
+        """
+        persistence.clear_room(self._current_room)
         self._history.clear()
         self._active_personas.clear()
+
+    def load_room(self, room_name: str):
+        """Load persisted history for a room into the active session.
+
+        Clears any existing in-memory history first, then populates from disk.
+        Uses no-persist variants since messages are already on disk.
+        """
+        self._history.clear()
+        self._current_room = room_name
+        persisted = persistence.load_history(room_name)
+        for msg in persisted:
+            if msg["sender"] == "USER":
+                self.add_user_message_no_persist(msg["text"])
+            else:
+                self.add_assistant_message_no_persist(msg["text"], msg["sender"])
 
     def set_active_personas(self, names: List[str]):
         """Replace the active persona list."""
@@ -35,12 +71,28 @@ class SessionManager:
     def history(self) -> List[ChatMessage]:
         return list(self._history)
 
-    def add_user_message(self, content: str):
-        """Append a user message to history."""
+    def add_user_message(self, content: str, message_id: str):
+        """Append a user message to history and persist it."""
+        self._history.append(ChatMessage(role="user", content=content))
+        persistence.persist_message(self._current_room, self._history[-1], message_id)
+
+    def add_assistant_message(self, content: str, persona: str, message_id: str):
+        """Append an assistant message to history and persist it."""
+        self._history.append(ChatMessage(role="assistant", content=content, persona=persona))
+        persistence.persist_message(self._current_room, self._history[-1], message_id)
+
+    def add_user_message_no_persist(self, content: str):
+        """Append a user message to history without persisting.
+
+        Used when loading from disk (messages are already persisted).
+        """
         self._history.append(ChatMessage(role="user", content=content))
 
-    def add_assistant_message(self, content: str, persona: str):
-        """Append an assistant message to history."""
+    def add_assistant_message_no_persist(self, content: str, persona: str):
+        """Append an assistant message to history without persisting.
+
+        Used when loading from disk (messages are already persisted).
+        """
         self._history.append(ChatMessage(role="assistant", content=content, persona=persona))
 
     def build_llm_messages(

--- a/chatrooms.yaml
+++ b/chatrooms.yaml
@@ -1,0 +1,1 @@
+chat_rooms: []

--- a/docs/feature_chat_persistence.md
+++ b/docs/feature_chat_persistence.md
@@ -1,0 +1,101 @@
+# Chat persistence
+
+This document describes how the TalkWithMe app should handle a new feature - chat persistence.
+
+## Current state
+
+The app currently maintains a single chat session in-memory. 
+Selecting "New Chat" clears any existing chat history and begins a new blank chat.
+Switching between chat rooms also clears chat history and begins a new chat.
+
+## Desired state
+
+Each chat room (including the implicit "default" room) should persist its chat history to disk.
+Switching from room A to room B should clear the chat display and then load/display the persisted chat history for room B.
+Switching back to room B should clear the chat display and then load/display the persisted chat history for room A.
+
+Chat messages should be persisted as they arrive (either from the remote LLM or from user input).
+
+### Persistence format
+
+A new top-level directory called `chatrooms` will be used for persistence.
+It is not an error if `chatrooms` does not exist on startup - it can be created as needed.
+
+Each chat room will persist its chat messages to a dedicated subdirectory within the top-level `chatrooms` directory.
+For example, a chat room called "chit-chat" would persist to `chatrooms/chit-chat/`. The implicit "default" chatroom
+would persist to `chatrooms/default/`.
+
+Within the chatroom's subdirectory, a single json file will be used to store all chat messages.
+
+```
+{
+  "datetime": "<ISO-8601 timestamp of most recent message, in the system's local timezone>",
+  "messages": [
+    {
+      "id": "<unique UUID for this message>",
+      "sender": "<persona name OR the fixed string USER for user messages>",
+      "text": "<escaped text content suitable for Json storage>",
+      "audio": [
+        "filename1",
+        "filename2",
+        ...
+      ]
+    },
+    ...
+  ]
+}
+```
+
+Audio files (if any) associated with each message are written to the chatroom's dedicated subdirectory
+using the message UUID and an appended index as the filename. For example:
+
+```
+d4ee3044-5f77-4af5-8b3c-54c07e5d45e0_1.wav
+d4ee3044-5f77-4af5-8b3c-54c07e5d45e0_2.wav
+```
+
+These filenames can then be listed in the `audio` array for the message:
+
+```
+  "audio": [
+    "d4ee3044-5f77-4af5-8b3c-54c07e5d45e0_1.wav",
+    "d4ee3044-5f77-4af5-8b3c-54c07e5d45e0_2.wav"
+  ]
+```
+
+It is not an error condition for the `audio` array to be empty. There may legitimately be no audio associated with a given message.
+
+### New messages
+
+Every time a new message is added to a chat, whether it came from the remote LLM or from user input, the chat persistence
+file for the current chatroom is created or updated as needed. A random v4 UUID will be generated for each new message,
+and used as that message's unique id.
+
+### Audio
+
+Some messages may have audio associated with them:
+
+- user messages can be input from the microphone with MediaRecorder and supplied to a configured STT server for transcription.
+- persona messages can be sent to a configured TTS server to synthesize speech from them.
+
+In both cases, the generated audio should be captured and written to the chatroom's persistence subdirectory, using
+the unique UUID for the associated message.
+
+It's possible for more than one audio file to be associated with a message. This can happen with the TTS server, if
+`streaming` mode is enabled - the persona's message is chunked into sentences and sent up as multiple TTS synthesis requests.
+In this case, all audio files must be captured in the proper sequence and persisted. The file extension should be driven
+from the mime type of the audio, with ".bin" as a fallback extension if the mime type cannot be determined.
+
+## Clearing the chat
+
+When the user selects "New Chat", the chat history for that room can be cleared. This is a simple matter of deleting
+all files in that chat room's dedicated persistence subdirectory. The subdirectory itself need not be removed.
+
+Switching between chat rooms does NOT remove persisted chat history. This is a change from the current in-memory behavior,
+where chat history from the room that the user is leaving is instantly lost. 
+
+## Configuration
+
+This new feature is not optional. There is no need to add a new configuration option for it. Chat persistence simply
+happens automatically in every chat room, including the implicit "default" chat room. 
+

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,22 +1,19 @@
 llm:
   base_url: http://saturn-lm:8080
-  model: "default"
+  model: default
   max_tokens: 1024
   temperature: 0.8
-
 tts:
   enabled: true
   base_url: http://saturn-lm:8181
-  num_steps: 12
-  guidance_scale: 1.7
+  num_steps: 14
+  guidance_scale: 1.5
   seed: null
-  timeout: 120
-  streaming: false
-
+  timeout: 120.0
+  streaming: true
 stt:
   enabled: true
-  base_url: http://saturn-lm:8181
-  timeout: 30
-
+  base_url: http://saturn-lm:5000
+  timeout: 30.0
 general:
   persona_name_mentions: true

--- a/static/app.js
+++ b/static/app.js
@@ -22,7 +22,10 @@ async function init() {
     await loadGeneralSettings();
     setupEventListeners();
     setupChatRoomEventListeners();
-    showEmptyState();
+
+    // Load persisted history for the current room
+    const history = await loadPersistedHistory(currentChatRoom);
+    renderPersistedHistory(history.messages, currentChatRoom);
 }
 
 /**
@@ -134,6 +137,8 @@ function setupEventListeners() {
 
 async function newChat() {
     try {
+        // POST /api/session/new clears both the in-memory session AND
+        // the persisted files for the current room.
         await fetch("/api/session/new", { method: "POST" });
         messagesEl.innerHTML = "";
         showEmptyState();

--- a/static/chat.js
+++ b/static/chat.js
@@ -225,6 +225,8 @@ function handleSSEEvent(event, assistantRow) {
                 if (assistantRow) {
                     assistantRow.dataset.messageId = event.message_id;
                 }
+                // Persist any streaming-mode audio that was buffered before the ID was known.
+                flushTtsAudioBuffer(event.message_id);
             }
 
             if (ttsEnabled && event.text) {

--- a/static/chat.js
+++ b/static/chat.js
@@ -3,6 +3,7 @@
  *
  * Handles the full message lifecycle: user input → POST to server →
  * streaming SSE response → TTS enqueue → bubble rendering.
+ * Also handles rendering persisted chat history from disk.
  */
 
 /* ==========================================================================
@@ -94,8 +95,14 @@ async function sendMessage() {
         messagesEl.innerHTML = "";
     }
 
-    // Append user bubble
-    appendUserBubble(text);
+    // Generate a UUID for this user message (used for audio association).
+    // If STT already generated one (for audio upload), reuse it.
+    if (!pendingUserMessageId) {
+        pendingUserMessageId = crypto.randomUUID();
+    }
+
+    // Append user bubble with the message ID
+    appendUserBubble(text, pendingUserMessageId);
     inputEl.value = "";
     inputEl.style.height = "auto";
 
@@ -112,7 +119,12 @@ async function sendMessage() {
         const resp = await fetch("/api/chat", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ message: text, who_answers: who }),
+            body: JSON.stringify({
+                message: text,
+                who_answers: who,
+                chat_room: currentChatRoom,
+                message_id: pendingUserMessageId,
+            }),
         });
 
         if (!resp.ok || !resp.body) {
@@ -145,11 +157,13 @@ async function sendMessage() {
                 }
             }
         }
+    } catch (err) {
         console.error("Chat error:", err);
         handleSSEEvent({ type: "error", message: "Connection failed. Is the LLM server running?" }, assistantRow);
     } finally {
         isStreaming = false;
         sendBtn.disabled = false;
+        pendingUserMessageId = null;
         inputEl.focus();
     }
 }
@@ -161,6 +175,11 @@ async function sendMessage() {
 function handleSSEEvent(event, assistantRow) {
     switch (event.type) {
         case "start": {
+            // A new response is starting — clear any leftover message ID from
+            // the previous response so its late-arriving audio doesn't get
+            // associated with this new message.
+            currentAssistantMessageId = null;
+
             // Update the bubble with the actual persona name
             const persona = personas.find(p => p.name === event.persona);
             setupAssistantBubble(assistantRow, persona || { name: event.persona, avatar_color: "#888" });
@@ -195,6 +214,19 @@ function handleSSEEvent(event, assistantRow) {
             break;
         }
         case "done": {
+            // Track the assistant message ID for TTS audio association.
+            // In streaming mode, async audio fetches are still in-flight when
+            // this event arrives. They will use currentAssistantMessageId as
+            // a fallback when they resolve (see fetchTTS).
+            if (event.message_id) {
+                currentAssistantMessageId = event.message_id;
+                // Tag the live assistant bubble with the message ID so audio
+                // buttons can be injected into the correct DOM node later.
+                if (assistantRow) {
+                    assistantRow.dataset.messageId = event.message_id;
+                }
+            }
+
             if (ttsEnabled && event.text) {
                 const persona = personas.find(p => p.name === event.persona);
                 if (persona && persona.tts_capable) {
@@ -222,7 +254,9 @@ function handleSSEEvent(event, assistantRow) {
             break;
         }
         case "complete": {
-            // Final signal — nothing to do
+            // Final signal — don't clear currentAssistantMessageId here.
+            // In streaming mode, async audio fetches may still be in-flight.
+            // The ID will be cleared by the next "start" event instead.
             break;
         }
     }
@@ -232,15 +266,24 @@ function handleSSEEvent(event, assistantRow) {
    Bubble creation
    ========================================================================== */
 
-function appendUserBubble(text) {
+function appendUserBubble(text, messageId) {
     const row = document.createElement("div");
     row.className = "message-row user";
+    if (messageId) {
+        row.dataset.messageId = messageId;
+    }
+
+    // Wrapper keeps bubble + audio stacked vertically (row-reverse would
+    // otherwise place audio to the left of the bubble).
+    const wrapper = document.createElement("div");
+    wrapper.className = "user-message-content";
 
     const bubble = document.createElement("div");
     bubble.className = "bubble";
     bubble.textContent = text;
 
-    row.appendChild(bubble);
+    wrapper.appendChild(bubble);
+    row.appendChild(wrapper);
     messagesEl.appendChild(row);
     scrollToBottom();
 }
@@ -320,4 +363,229 @@ function appendErrorBubble(text) {
     row.appendChild(bubble);
     messagesEl.appendChild(row);
     scrollToBottom();
+}
+
+/* ==========================================================================
+   Persisted history rendering
+   ========================================================================== */
+
+/**
+ * Render persisted chat history into the message panel.
+ * Called when loading a room's history from disk.
+ */
+function renderPersistedHistory(messages, roomName) {
+    messagesEl.innerHTML = "";
+
+    if (!messages || messages.length === 0) {
+        showEmptyState();
+        return;
+    }
+
+    for (const msg of messages) {
+        if (msg.sender === "USER") {
+            appendPersistedUserBubble(msg, roomName);
+        } else {
+            appendPersistedAssistantBubble(msg, roomName);
+        }
+    }
+
+    scrollToBottom();
+}
+
+function appendPersistedUserBubble(msg, roomName) {
+    const row = document.createElement("div");
+    row.className = "message-row user";
+    if (msg.id) {
+        row.dataset.messageId = msg.id;
+    }
+
+    // Wrapper keeps bubble + audio stacked vertically.
+    const wrapper = document.createElement("div");
+    wrapper.className = "user-message-content";
+
+    const bubble = document.createElement("div");
+    bubble.className = "bubble";
+    bubble.textContent = msg.text;
+
+    wrapper.appendChild(bubble);
+
+    // Add audio playback buttons if this message has audio files
+    if (msg.audio && msg.audio.length > 0) {
+        const audioContainer = document.createElement("div");
+        audioContainer.className = "message-audio";
+        for (const filename of msg.audio) {
+            const playBtn = document.createElement("button");
+            playBtn.className = "audio-play-btn";
+            playBtn.innerHTML = "\u{1F501}"; // play icon
+            playBtn.title = "Play audio";
+            playBtn.addEventListener("click", () => playPersistedAudio(roomName, filename));
+            audioContainer.appendChild(playBtn);
+        }
+        wrapper.appendChild(audioContainer);
+    }
+
+    row.appendChild(wrapper);
+    messagesEl.appendChild(row);
+}
+
+function appendPersistedAssistantBubble(msg, roomName) {
+    const row = document.createElement("div");
+    row.className = "message-row assistant";
+    if (msg.id) {
+        row.dataset.messageId = msg.id;
+    }
+
+    // Find persona info for avatar
+    const persona = personas.find(p => p.name === msg.sender);
+    const personaData = persona || { name: msg.sender, avatar_color: "#888" };
+
+    // Avatar
+    const avatar = document.createElement("div");
+    avatar.className = "bubble-avatar";
+    avatar.style.backgroundColor = personaData.avatar_color;
+
+    if (persona && persona.avatar_image) {
+        const img = document.createElement("img");
+        img.src = `/api/personas/${encodeURIComponent(persona.name)}/avatar`;
+        img.alt = persona.name;
+        img.onerror = () => {
+            avatar.innerHTML = persona.name.charAt(0).toUpperCase();
+        };
+        avatar.appendChild(img);
+    } else {
+        avatar.textContent = personaData.name.charAt(0).toUpperCase();
+    }
+
+    const content = document.createElement("div");
+    content.className = "bubble-content";
+
+    const nameEl = document.createElement("div");
+    nameEl.className = "bubble-name";
+    nameEl.textContent = personaData.name;
+
+    const bubble = document.createElement("div");
+    bubble.className = "bubble";
+    bubble.textContent = msg.text;
+
+    // Add audio playback buttons if this message has audio files
+    if (msg.audio && msg.audio.length > 0) {
+        const audioContainer = document.createElement("div");
+        audioContainer.className = "message-audio";
+        for (const filename of msg.audio) {
+            const playBtn = document.createElement("button");
+            playBtn.className = "audio-play-btn";
+            playBtn.innerHTML = "\u{1F501}"; // 🔁 play icon
+            playBtn.title = "Play audio";
+            playBtn.addEventListener("click", () => playPersistedAudio(roomName, filename));
+            audioContainer.appendChild(playBtn);
+        }
+        content.appendChild(nameEl);
+        content.appendChild(bubble);
+        content.appendChild(audioContainer);
+    } else {
+        content.appendChild(nameEl);
+        content.appendChild(bubble);
+    }
+
+    row.appendChild(avatar);
+    row.appendChild(content);
+    messagesEl.appendChild(row);
+}
+
+/**
+ * Play a persisted audio file using Web Audio API.
+ */
+async function playPersistedAudio(roomName, filename) {
+    const url = getAudioUrl(roomName, filename);
+    try {
+        const resp = await fetch(url);
+        if (!resp.ok) {
+            console.warn(`Failed to fetch audio: HTTP ${resp.status}`);
+            return;
+        }
+        const arrayBuffer = await resp.arrayBuffer();
+
+        if (!audioCtx) {
+            audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+        }
+
+        const audioBuffer = await audioCtx.decodeAudioData(arrayBuffer);
+        const source = audioCtx.createBufferSource();
+        source.buffer = audioBuffer;
+        source.connect(audioCtx.destination);
+        source.start();
+    } catch (err) {
+        console.error("Failed to play persisted audio:", err);
+    }
+}
+
+/**
+ * Inject an audio playback button into a live assistant bubble.
+ * Called from tts.js after each audio file is persisted.
+ *
+ * @param {string} messageId - The message ID to locate the bubble by.
+ * @param {string} filename - The persisted audio filename.
+ */
+function addAudioButtonToAssistantMessage(messageId, filename) {
+    const row = messagesEl.querySelector(`.message-row.assistant[data-message-id="${messageId}"]`);
+    if (!row) {
+        console.warn("addAudioButtonToAssistantMessage: no bubble found for message", messageId);
+        return;
+    }
+
+    const content = row.querySelector(".bubble-content");
+    if (!content) return;
+
+    // Lazily create the audio container on first button
+    let audioContainer = content.querySelector(".message-audio");
+    if (!audioContainer) {
+        audioContainer = document.createElement("div");
+        audioContainer.className = "message-audio";
+        content.appendChild(audioContainer);
+    }
+
+    const playBtn = document.createElement("button");
+    playBtn.className = "audio-play-btn";
+    playBtn.innerHTML = "\u{1F501}"; // play icon
+    playBtn.title = "Play audio";
+    playBtn.addEventListener("click", () => playPersistedAudio(currentChatRoom, filename));
+    audioContainer.appendChild(playBtn);
+}
+
+/**
+ * Inject an audio playback button into a live user bubble.
+ * Called from stt.js after the recorded audio is persisted.
+ * Uses a retry mechanism in case the bubble isn't in the DOM yet.
+ *
+ * @param {string} messageId - The message ID to locate the bubble by.
+ * @param {string} filename - The persisted audio filename.
+ */
+function addAudioButtonToUserMessage(messageId, filename, retries = 3) {
+    const row = messagesEl.querySelector(`.message-row.user[data-message-id="${messageId}"]`);
+    if (!row) {
+        if (retries > 0) {
+            // Bubble not in DOM yet — retry after a short delay.
+            setTimeout(() => addAudioButtonToUserMessage(messageId, filename, retries - 1), 150);
+        }
+        return;
+    }
+
+    // User bubbles use a .user-message-content wrapper for proper stacking.
+    const wrapper = row.querySelector(".user-message-content");
+    if (!wrapper) return;
+
+    // Lazily create the audio container on first button
+    let audioContainer = wrapper.querySelector(".message-audio");
+    if (!audioContainer) {
+        audioContainer = document.createElement("div");
+        audioContainer.className = "message-audio";
+        wrapper.appendChild(audioContainer);
+    }
+
+    const playBtn = document.createElement("button");
+    playBtn.className = "audio-play-btn";
+    playBtn.innerHTML = "\u{1F501}"; // play icon
+    playBtn.title = "Play audio";
+    playBtn.addEventListener("click", () => playPersistedAudio(currentChatRoom, filename));
+    audioContainer.appendChild(playBtn);
 }

--- a/static/chatrooms.js
+++ b/static/chatrooms.js
@@ -301,6 +301,11 @@ async function createChatRoom() {
         crFormError.classList.remove("hidden");
         return;
     }
+    if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+        crFormError.textContent = "Name may only contain letters, numbers, hyphens, and underscores.";
+        crFormError.classList.remove("hidden");
+        return;
+    }
 
     try {
         const resp = await fetch("/api/chatrooms", {

--- a/static/chatrooms.js
+++ b/static/chatrooms.js
@@ -160,19 +160,19 @@ function setupChatRoomEventListeners() {
    ========================================================================== */
 
 /**
- * Switch to a different chat room. Clears the chat panel and updates the
- * persona list to match the room's assigned personas.
+ * Switch to a different chat room. Clears the chat display, loads the
+ * persisted history for the new room, and updates the persona list.
  */
-function switchChatRoom(roomName) {
+async function switchChatRoom(roomName) {
     currentChatRoom = roomName;
 
-    // Clear chat panel — same as "New Chat"
+    // Clear chat panel momentarily
     messagesEl.innerHTML = "";
     showEmptyState();
 
-    // Reset session history on backend
-    fetch("/api/session/new", { method: "POST" })
-        .catch(err => console.error("Failed to reset session:", err));
+    // Load persisted history for this room (also resets the backend session)
+    const history = await loadPersistedHistory(roomName);
+    renderPersistedHistory(history.messages, roomName);
 
     // Re-apply filter
     applyChatRoomFilter();

--- a/static/persistence.js
+++ b/static/persistence.js
@@ -1,0 +1,102 @@
+/**
+ * persistence.js — Chat history persistence helpers.
+ *
+ * Handles loading persisted chat history from the server and uploading
+ * audio files for messages.
+ */
+
+/* ==========================================================================
+    History loading
+    ========================================================================== */
+
+/**
+ * Load persisted chat history for a room from the server.
+ * Returns the response body (includes messages with IDs and audio file refs).
+ */
+async function loadPersistedHistory(roomName) {
+    try {
+        const resp = await fetch(`/api/session/load-room/${encodeURIComponent(roomName)}`);
+        if (!resp.ok) {
+            console.warn(`Failed to load history for room '${roomName}': HTTP ${resp.status}`);
+            return { room: roomName, messages: [] };
+        }
+        return await resp.json();
+    } catch (err) {
+        console.error("Failed to load persisted history:", err);
+        return { room: roomName, messages: [] };
+    }
+}
+
+/* ==========================================================================
+    Audio upload
+    ========================================================================== */
+
+/**
+ * Upload an audio file (base64) for a persisted message.
+ *
+ * @param {string} roomName - The chat room this audio belongs to.
+ * @param {string} messageId - The UUID of the message this audio is for.
+ * @param {string} audioBase64 - Base64-encoded audio data.
+ * @param {string} [mimeType] - Optional MIME type of the audio.
+ */
+async function uploadAudio(roomName, messageId, audioBase64, mimeType) {
+    try {
+        const params = new URLSearchParams({ room: roomName });
+        const resp = await fetch(`/api/persist/audio?${params}`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                message_id: messageId,
+                audio_base64: audioBase64,
+                mime_type: mimeType || undefined,
+            }),
+        });
+        if (!resp.ok) {
+            console.warn(`Audio upload failed for message ${messageId}: HTTP ${resp.status}`);
+            return null;
+        }
+        return await resp.json();
+    } catch (err) {
+        console.error("Failed to upload audio:", err);
+        return null;
+    }
+}
+
+/**
+ * Upload audio from a Blob (e.g., a MediaRecorder recording).
+ * Converts the blob to base64 before uploading.
+ *
+ * @param {string} roomName - The chat room this audio belongs to.
+ * @param {string} messageId - The UUID of the message this audio is for.
+ * @param {Blob} blob - The audio blob.
+ * @param {string} mimeType - The MIME type of the blob.
+ */
+async function uploadAudioBlob(roomName, messageId, blob, mimeType) {
+    const base64 = await blobToBase64(blob);
+    // blobToBase64 returns a data URL; strip the prefix
+    const raw = base64.split(",")[1];
+    return uploadAudio(roomName, messageId, raw, mimeType);
+}
+
+/**
+ * Read a Blob as a base64 data URL.
+ */
+function blobToBase64(blob) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = reject;
+        reader.readAsDataURL(blob);
+    });
+}
+
+/* ==========================================================================
+    Audio playback
+    ========================================================================== */
+
+/**
+ * Get the URL for a persisted audio file.
+ */
+function getAudioUrl(roomName, filename) {
+    return `/api/persist/audio/${encodeURIComponent(roomName)}/${encodeURIComponent(filename)}`;
+}

--- a/static/persona.js
+++ b/static/persona.js
@@ -272,6 +272,7 @@ async function submitPersonaForm(e) {
     const refAudioTx   = pfReferenceAudioTx.value.trim();
 
     if (!name) return showPersonaFormError("Name is required.");
+    if (name.toLowerCase() === "user") return showPersonaFormError("'user' is a reserved name and cannot be used.");
     if (!systemPrompt) return showPersonaFormError("System prompt is required.");
     if (!routerHints) return showPersonaFormError("Router hints are required.");
     if (language.length !== 2) return showPersonaFormError("Language must be a 2-letter code.");

--- a/static/state.js
+++ b/static/state.js
@@ -42,6 +42,13 @@ const audioBufferQueue = [];
 let isFetchingTTS = false;
 let isPlayingAudioBuffer = false;
 
+// Chat persistence — track message IDs for audio association
+let pendingUserMessageId = null; // UUID generated before sending, used for STT audio
+let currentAssistantMessageId = null; // UUID from server's "done" event, used for TTS audio
+// Buffers audio fetched during streaming TTS (before message_id is known).
+// Each entry: { audio_base64, mime_type }. Flushed when "done" event arrives.
+let ttsAudioBuffer = [];
+
 const THEME_STORAGE_KEY = "talkwithme_theme";
 
 /* ==========================================================================

--- a/static/stt.js
+++ b/static/stt.js
@@ -77,6 +77,23 @@ async function toggleMicrophone() {
                 const existing = inputEl.value;
                 inputEl.value = existing ? existing + " " + data.text : data.text;
                 inputEl.dispatchEvent(new Event("input")); // trigger auto-resize
+
+                // Persist the recorded audio before sending the message.
+                // pendingUserMessageId is set by sendMessage() right before the
+                // message is sent, but we need it here *before* sendMessage().
+                // So we generate it now if it's not already set.
+                if (!pendingUserMessageId) {
+                    pendingUserMessageId = crypto.randomUUID();
+                }
+                uploadAudioBlob(currentChatRoom, pendingUserMessageId, blob, audioMimeType)
+                    .then(result => {
+                        if (result && result.filename) {
+                            // Inject a playback button into the live user bubble
+                            addAudioButtonToUserMessage(pendingUserMessageId, result.filename);
+                        }
+                    })
+                    .catch(err => console.warn("Failed to persist STT audio:", err));
+
                 sendMessage();
             }
         } catch (err) {

--- a/static/stt.js
+++ b/static/stt.js
@@ -85,15 +85,16 @@ async function toggleMicrophone() {
                 if (!pendingUserMessageId) {
                     pendingUserMessageId = crypto.randomUUID();
                 }
-                uploadAudioBlob(currentChatRoom, pendingUserMessageId, blob, audioMimeType)
-                    .then(result => {
-                        if (result && result.filename) {
-                            // Inject a playback button into the live user bubble
-                            addAudioButtonToUserMessage(pendingUserMessageId, result.filename);
-                        }
-                    })
-                    .catch(err => console.warn("Failed to persist STT audio:", err));
 
+                try {
+                    const result = await uploadAudioBlob(currentChatRoom, pendingUserMessageId, blob, audioMimeType);
+                    if (result && result.filename) {
+                        // Inject a playback button into the live user bubble
+                        addAudioButtonToUserMessage(pendingUserMessageId, result.filename);
+                    }
+                } catch (err) {
+                    console.warn("Failed to persist STT audio:", err);
+                }
                 sendMessage();
             }
         } catch (err) {

--- a/static/style.css
+++ b/static/style.css
@@ -1235,3 +1235,44 @@ html, body {
     text-align: center;
     padding: 24px 0;
 }
+
+/* ==========================================================================
+   Message audio playback (persisted chat)
+   ========================================================================== */
+
+/* Wrapper for user messages — keeps bubble + audio stacked vertically
+   despite the row using flex-direction: row-reverse. */
+.user-message-content {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+}
+
+.message-audio {
+    display: flex;
+    gap: 6px;
+    margin-top: 6px;
+    flex-wrap: wrap;
+}
+
+.audio-play-btn {
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    padding: 3px 8px;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+    line-height: 1;
+}
+
+.audio-play-btn:hover {
+    background: var(--accent);
+    color: #fff;
+    border-color: var(--accent);
+}
+
+.audio-play-btn:active {
+    transform: scale(0.95);
+}

--- a/static/tts.js
+++ b/static/tts.js
@@ -4,6 +4,10 @@
  * Supports two modes:
  *  - Non-streaming: enqueue full text after LLM finishes responding.
  *  - Streaming: split response into sentences, fetch and play in a pipeline.
+ *
+ * Audio persistence: each TTS fetch carries its own message ID so audio
+ * is always associated with the correct message, even when the global
+ * currentAssistantMessageId has been cleared by a subsequent message.
  */
 
 /* ==========================================================================
@@ -31,7 +35,10 @@ function toggleTTS() {
    ========================================================================== */
 
 function enqueueTTS(personaName, text) {
-    audioQueue.push({ personaName, text });
+    // Capture the current assistant message ID so this audio request
+    // knows which message it belongs to, even if the global ID changes
+    // before the async fetch completes.
+    audioQueue.push({ personaName, text, messageId: currentAssistantMessageId });
     processAudioQueue();
 }
 
@@ -41,7 +48,7 @@ async function processAudioQueue() {
 
     const item = audioQueue.shift();
     try {
-        const audioBuffer = await fetchTTS(item.personaName, item.text);
+        const audioBuffer = await fetchTTS(item.personaName, item.text, item.messageId);
         if (audioBuffer) {
             await playAudio(audioBuffer);
         }
@@ -88,7 +95,9 @@ function accumulateForTTS(token, personaName) {
 
 /** Push a sentence into the fetch queue and kick off the fetch pipeline. */
 function enqueueStreamingTTS(personaName, text) {
-    ttsRequestQueue.push({ personaName, text });
+    // In streaming mode, message_id isn't known until the "done" event.
+    // Pass null here; the buffer will be flushed with the correct ID later.
+    ttsRequestQueue.push({ personaName, text, messageId: null });
     processTTSRequests();
 }
 
@@ -103,7 +112,7 @@ async function processTTSRequests() {
 
     const item = ttsRequestQueue.shift();
     try {
-        const audioBuffer = await fetchTTS(item.personaName, item.text);
+        const audioBuffer = await fetchTTS(item.personaName, item.text, item.messageId);
         if (audioBuffer) {
             audioBufferQueue.push(audioBuffer);
             processAudioBufferQueue();
@@ -142,7 +151,16 @@ async function processAudioBufferQueue() {
    Shared TTS helpers
    ========================================================================== */
 
-async function fetchTTS(personaName, text) {
+/**
+ * Fetch TTS audio from the server and persist it to disk.
+ *
+ * @param {string} personaName - Which persona to synthesize for.
+ * @param {string} text - Text to synthesize.
+ * @param {string|null} messageId - The message ID this audio belongs to.
+ *   If null (streaming mode), falls back to currentAssistantMessageId,
+ *   which is set by the "done" event handler before audio fetches complete.
+ */
+async function fetchTTS(personaName, text, messageId) {
     const resp = await fetch("/api/tts", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -157,7 +175,25 @@ async function fetchTTS(personaName, text) {
     const data = await resp.json();
     if (!data.audio_base64) return null;
 
-    // Decode base64 to ArrayBuffer
+    // Use the passed messageId if available (non-streaming), otherwise fall
+    // back to the global currentAssistantMessageId (streaming mode, where the
+    // "done" event sets it before async audio fetches resolve).
+    const effectiveId = messageId || currentAssistantMessageId;
+    if (effectiveId) {
+        uploadAudio(currentChatRoom, effectiveId, data.audio_base64, "audio/wav")
+            .then(result => {
+                if (result && result.filename) {
+                    // Inject a playback button into the live chat bubble
+                    addAudioButtonToAssistantMessage(effectiveId, result.filename);
+                }
+            })
+            .catch(err => console.warn("Failed to persist TTS audio:", err));
+    } else {
+        // Safety net: if somehow no ID is available, buffer for later flush.
+        ttsAudioBuffer.push({ audio_base64: data.audio_base64, mime_type: "audio/wav" });
+    }
+
+    // Decode base64 to ArrayBuffer for playback
     const binary = atob(data.audio_base64);
     const bytes = new Uint8Array(binary.length);
     for (let i = 0; i < binary.length; i++) {
@@ -180,4 +216,25 @@ function playAudio(buffer) {
         source.onended = resolve;
         source.start();
     });
+}
+
+/**
+ * Persist any audio buffered during streaming TTS.
+ *
+ * During streaming, TTS sentences are fetched as tokens arrive, but the
+ * assistant's message_id isn't known until the "done" event. This function
+ * flushes the buffer once the ID is available.
+ */
+function flushTtsAudioBuffer(messageId) {
+    if (!messageId || ttsAudioBuffer.length === 0) return;
+    for (const entry of ttsAudioBuffer) {
+        uploadAudio(currentChatRoom, messageId, entry.audio_base64, entry.mime_type)
+            .then(result => {
+                if (result && result.filename) {
+                    addAudioButtonToAssistantMessage(messageId, result.filename);
+                }
+            })
+            .catch(err => console.warn("Failed to persist buffered TTS audio:", err));
+    }
+    ttsAudioBuffer = [];
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -109,7 +109,7 @@
                     <div class="form-row">
                         <label for="pf-name">Name <span class="required">*</span></label>
                         <input id="pf-name" type="text" maxlength="25" placeholder="Max 25 chars" required>
-                        <span class="field-hint">25 chars max, must be unique</span>
+                        <span class="field-hint">25 chars max, must be unique (not 'user')</span>
                     </div>
                     <div class="form-row">
                         <label for="pf-description">Description</label>
@@ -186,7 +186,7 @@
                 <div class="form-row" style="padding: 12px 20px;">
                     <label for="cr-name-input">Room Name <span class="required">*</span></label>
                     <input id="cr-name-input" type="text" maxlength="20" placeholder="Max 20 chars">
-                    <span class="field-hint">20 chars max, must be unique (not 'default')</span>
+                    <span class="field-hint">Letters, numbers, hyphens, underscores only. 20 chars max, must be unique (not 'default')</span>
                 </div>
                 <div class="form-actions">
                     <button type="button" id="cr-new-cancel" class="btn-secondary">Cancel</button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -343,6 +343,7 @@
     <script src="/static/state.js"></script>
     <script src="/static/utils.js"></script>
     <script src="/static/theme.js"></script>
+    <script src="/static/persistence.js"></script>
     <script src="/static/tts.js"></script>
     <script src="/static/stt.js"></script>
     <script src="/static/chat.js"></script>


### PR DESCRIPTION
This PR addresses two issues together:

- #4 - each chat room now persists its chat history (both text and audio) in a dedicated persistence directory. Chat history is kept until manually cleared by the user via the "New Chat" control.
- #5 - "replay" buttons are dynamically added underneath all chat bubbles that have associated audio. Clicking "replay" plays directly from persistence, no TTS regeneration needed.

Updated the agent instruction files and the README to include these changes.