### PR TITLE
Issue #36 - add read-only serverType to TTS settings UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ app/routers/__pycache__/
 personas.yaml.*
 future*.md
 chatrooms/
+chatrooms.yaml.*

--- a/app/models.py
+++ b/app/models.py
@@ -146,6 +146,10 @@ class TTSHealthResponse(BaseModel):
         default=False,
         description="True if streaming (sentence-by-sentence) TTS mode is configured",
     )
+    server_type: Optional[str] = Field(
+        default=None,
+        description="Server type reported by the TTS server's /health endpoint (e.g. dots.tts)",
+    )
 
 
 class STTHealthResponse(BaseModel):

--- a/app/routers/tts.py
+++ b/app/routers/tts.py
@@ -23,11 +23,12 @@ router = APIRouter(tags=["tts"])
 async def tts_health():
     """Report TTS availability status to the frontend."""
     settings = get_settings()
-    available = await check_tts_health() if settings.tts.is_active else False
+    available, server_type = await check_tts_health() if settings.tts.is_active else (False, None)
     return TTSHealthResponse(
         enabled=settings.tts.is_active,
         available=available,
         streaming=settings.tts.streaming,
+        server_type=server_type,
     )
 
 

--- a/app/services/tts_client.py
+++ b/app/services/tts_client.py
@@ -19,21 +19,31 @@ from app.config import get_settings
 logger = logging.getLogger(__name__)
 
 
-async def check_tts_health() -> bool:
-    """Return True if the TTS server is reachable.
+async def check_tts_health() -> tuple[bool, Optional[str]]:
+    """Return (is_reachable, server_type) from the TTS server's /health endpoint.
 
     Accepts both 200 (endpoint exists) and 404 (server is up but lacks /health).
     Any other outcome — connection error, timeout, 5xx — means the server is down.
+    server_type is extracted from the optional `serverType` field in the JSON response.
     """
     settings = get_settings()
     if not settings.tts.is_active:
-        return False
+        return False, None
     try:
         async with httpx.AsyncClient(timeout=3.0) as client:
             resp = await client.get(f"{settings.tts.base_url}/health")
-            return resp.status_code in (200, 404)
+            if resp.status_code not in (200, 404):
+                return False, None
+            # Extract serverType if the response body is valid JSON
+            server_type = None
+            try:
+                body = resp.json()
+                server_type = body.get("serverType")
+            except Exception:
+                pass  # Non-JSON or empty body is fine — just no server type
+            return True, server_type
     except Exception:
-        return False
+        return False, None
 
 
 async def synthesize(

--- a/static/app.js
+++ b/static/app.js
@@ -73,12 +73,14 @@ async function checkTTSHealth() {
         ttsAvailable = data.available;
         ttsStreaming = data.streaming || false;
         ttsEnabled = data.available; // Default on if server is available
+        ttsServerType = data.server_type || "";
         updateTTSToggleUI();
     } catch (err) {
         console.warn("TTS health check failed:", err);
         ttsAvailable = false;
         ttsStreaming = false;
         ttsEnabled = false;
+        ttsServerType = "";
         updateTTSToggleUI();
     }
 }

--- a/static/settings.js
+++ b/static/settings.js
@@ -39,6 +39,9 @@ async function openSettings() {
 
     const ok = await loadSettingsIntoForm();
     saveBtn.disabled = !ok;
+
+    // Server type is ephemeral — comes from health check, not settings
+    updateTtsServerTypeField();
 }
 
 function closeSettings() {
@@ -106,6 +109,11 @@ function updateSttFieldsState() {
     } else {
         sfSttFields.classList.add("disabled");
     }
+}
+
+// Display the TTS server type from the latest health check, truncated to 12 chars.
+function updateTtsServerTypeField() {
+    sfTtsServerType.value = ttsServerType.length > 12 ? ttsServerType.slice(0, 12) : ttsServerType;
 }
 
 function showSettingsError(msg) {

--- a/static/state.js
+++ b/static/state.js
@@ -15,6 +15,7 @@ let personaNameMentionsEnabled = true;
 let ttsEnabled = false;
 let ttsAvailable = false;
 let ttsStreaming = false;
+let ttsServerType = "";
 let sttAvailable = false;
 let isStreaming = false;
 
@@ -129,6 +130,7 @@ const sfTtsGuidanceScale = document.getElementById("sf-tts-guidance-scale");
 const sfTtsSeed = document.getElementById("sf-tts-seed");
 const sfTtsTimeout = document.getElementById("sf-tts-timeout");
 const sfTtsStreaming = document.getElementById("sf-tts-streaming");
+const sfTtsServerType = document.getElementById("sf-tts-server-type");
 
 // Settings form fields — STT
 const sfSttEnabled = document.getElementById("sf-stt-enabled");

--- a/static/style.css
+++ b/static/style.css
@@ -885,6 +885,17 @@ html, body {
     border-color: var(--accent);
 }
 
+// Read-only fields — slightly muted, no focus ring
+.form-input-readonly {
+    background: var(--bg-tertiary);
+    color: var(--text-muted);
+    cursor: default;
+}
+
+.form-input-readonly:focus {
+    border-color: var(--border-color);
+}
+
 .form-row input[type="color"] {
     width: 48px;
     height: 34px;

--- a/static/style.css
+++ b/static/style.css
@@ -885,14 +885,14 @@ html, body {
     border-color: var(--accent);
 }
 
-// Read-only fields — slightly muted, no focus ring
-.form-input-readonly {
+/* Read-only fields — slightly muted, no focus ring */
+.form-row input.form-input-readonly {
     background: var(--bg-tertiary);
     color: var(--text-muted);
     cursor: default;
 }
 
-.form-input-readonly:focus {
+.form-row input.form-input-readonly:focus {
     border-color: var(--border-color);
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -304,6 +304,10 @@
                                     <span>Streaming (sentence-by-sentence)</span>
                                 </label>
                             </div>
+                            <div class="form-row">
+                                <label for="sf-tts-server-type">Server Type</label>
+                                <input id="sf-tts-server-type" type="text" readonly class="form-input-readonly">
+                            </div>
                         </div>
                     </fieldset>
 


### PR DESCRIPTION
This PR addresses issue #36 by adding a read-only field in the TTS settings dialog to show the new `serverType` field being returned from the TTS server's health check endpoint. This value is not persisted and is not editable by the user - it's just shown for informational reasons.
