### PR TITLE
Issue #45 - relax chat room name regex to allow spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ application, depending on how much VRAM you can throw at it.
   - Add screenshots and better setup guidance to README (#17)
   - Add read-only "server type" field in TTS server settings (Qwen3-TTS or dots.tts) (#36)
 - **TODO All release notes for v4 go here**
+  - Relax chat room name restrictions to allow spaces (#45)
 
 ## License
 

--- a/app/routers/chatrooms.py
+++ b/app/routers/chatrooms.py
@@ -68,10 +68,10 @@ def create_chatroom(req: ChatRoomCreateRequest):
             status_code=409,
             detail=f"'{DEFAULT_ROOM}' is a reserved chat room name and cannot be created.",
         )
-    if not re.match(r'^[a-zA-Z0-9_-]+$', name):
+    if not re.match(r'^[a-zA-Z0-9 _-]+$', name):
         raise HTTPException(
             status_code=422,
-            detail="Room name may only contain letters, numbers, hyphens, and underscores.",
+            detail="Room name may only contain letters, numbers, spaces, hyphens, and underscores.",
         )
 
     config = get_chatrooms()

--- a/static/chatrooms.js
+++ b/static/chatrooms.js
@@ -301,8 +301,8 @@ async function createChatRoom() {
         crFormError.classList.remove("hidden");
         return;
     }
-    if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
-        crFormError.textContent = "Name may only contain letters, numbers, hyphens, and underscores.";
+    if (!/^[a-zA-Z0-9 _-]+$/.test(name)) {
+        crFormError.textContent = "Name may only contain letters, numbers, spaces, hyphens, and underscores.";
         crFormError.classList.remove("hidden");
         return;
     }


### PR DESCRIPTION
This PR addresses issue #45 by relaxing the chatroom name regex (on both front end and back end) to allow spaces in the name. The chat room name is also used to create the chat room persistence directory in the filesystem, which is why the regex exists in the first place. But excluding spaces seems too restrictive, since every modern filesystem allows spaces in directory names.