### PR TITLE
Issue #50 - avoid Jinja2 version 3.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ application, depending on how much VRAM you can throw at it.
 - **TODO All release notes for v4 go here**
   - Relax chat room name restrictions to allow spaces (#45)
   - Rename `language` to `reference_audio_language` in persona config (#46)
-  - Avoid Jinja2 version 3.1.5 due to known bug (#50)
+  - Avoid Jinja2 version 3.1.5 as a mitigation for #50
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ application, depending on how much VRAM you can throw at it.
 - **TODO All release notes for v4 go here**
   - Relax chat room name restrictions to allow spaces (#45)
   - Rename `language` to `reference_audio_language` in persona config (#46)
+  - Avoid Jinja2 version 3.1.5 due to known bug (#50)
 
 ## License
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fastapi
 uvicorn[standard]
 httpx
-jinja2
+jinja2>=3.1.2,<3.1.5
 pyyaml
 python-multipart
 aiofiles


### PR DESCRIPTION
This PR addresses issue #50 by modifying `requirements.txt` to avoid Jinja2 version 3.1.5 due to a known bug. Newer or older versions are fine, at least according to Copilot. I'm unable to reproduce the bug, even in a venv with Jinja2 `3.1.5` installed, so I have low confidence that this actually fixes the issue.