### PR TITLE
Issue #58 - fix scroll problems in personas dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ application, depending on how much VRAM you can throw at it.
   - Avoid Jinja2 version 3.1.5 as a mitigation for #50
   - Add "echo chamber" option to chat rooms (#51)
   - Add persona-to-persona chat with new option `max_persona_replies` (#43)
+  - Fix scroll problem in Personas dialog (#58)
 
 ## License
 

--- a/static/style.css
+++ b/static/style.css
@@ -419,12 +419,14 @@ html, body {
 
 /* Scrollbar styling */
 #messages::-webkit-scrollbar,
-#sidebar::-webkit-scrollbar {
+#sidebar::-webkit-scrollbar,
+.pe-list::-webkit-scrollbar {
     width: 6px;
 }
 
 #messages::-webkit-scrollbar-thumb,
-#sidebar::-webkit-scrollbar-thumb {
+#sidebar::-webkit-scrollbar-thumb,
+.pe-list::-webkit-scrollbar-thumb {
     background: var(--border-color);
     border-radius: 3px;
 }
@@ -771,7 +773,15 @@ html, body {
     background: #e74c3c;
 }
 
-/* Persona editor list */
+/* Persona editor list view — constrained so the list scrolls within the modal */
+#pe-list-view {
+    display: flex;
+    flex-direction: column;
+    max-height: 90vh;
+    overflow: hidden;
+}
+
+/* Persona editor list — capped so the form view (shown in-place during edit) has room */
 .pe-list {
     overflow-y: auto;
     padding: 12px 20px;
@@ -780,6 +790,7 @@ html, body {
     flex-direction: column;
     gap: 8px;
     min-height: 60px;
+    max-height: 45vh;
 }
 
 .pe-list-item {
@@ -859,11 +870,12 @@ html, body {
     padding: 24px 0;
 }
 
-/* Persona editor form */
+/* Persona editor form — constrained so long forms scroll within the modal */
 #pe-form-view {
-    overflow-y: auto;
     display: flex;
     flex-direction: column;
+    max-height: 90vh;
+    overflow: hidden;
 }
 
 #pe-form {
@@ -872,6 +884,8 @@ html, body {
     flex-direction: column;
     gap: 14px;
     overflow-y: auto;
+    flex: 1;
+    min-height: 0;
 }
 
 .form-row {


### PR DESCRIPTION
This PR addresses issue #58 by fixing the Personas dialog so that it maintains readability even when the personas list gets large. Previously, long personas lists would squish the edit panel down to an unusably small height. 