### PR TITLE
Issue #62 - fix audio misattribution bug

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,7 +46,7 @@ Every message is persisted to disk automatically — no configuration toggle nee
 
 - **Location**: `chatrooms/<room_name>/history.json` + audio files alongside it.
 - **Format**: JSON with `datetime` (ISO-8601) and `messages` array. Each message has `id` (UUID), `sender` ("USER" or persona name), `text`, and `audio` (array of filenames).
-- **Audio files**: Named `<message_uuid>_<index>.<ext>` (e.g. `d4ee3044_1.wav`). Extension derived from MIME type, falls back to `.bin`.
+**Audio files**: Named `<message_uuid>_<index>.<ext>` (e.g. `d4ee3044_1.wav`). Extension derived from MIME type, falls back to `.bin`. Audio that arrives *before* the message row exists (STT recordings upload before the chat request creates the user message; streaming TTS sentences upload while the reply is still streaming) is staged as `<message_uuid>_pending_<hex8>.<ext>` and automatically attached to the message's audio list when `persist_message()` runs — the staging registry lives in `app/persistence.py` (`_pending_audio`), in-memory only, so a process restart in that window leaves the (valid) file unreferenced.
 - **Room switching**: `GET /api/session/load-room/<room_name>` loads persisted history and populates the in-memory session.
 - **New Chat**: `POST /api/session/new` clears both in-memory history and deletes all files in the room's persistence directory.
 - **Audio upload**: `POST /api/persist/audio?room=<room>` accepts base64 audio and appends it to the message's audio list.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,8 @@ To force a re-read of all three files, call `app.config.reload_all()`.
 | `persistence.js` | History loading, audio upload helpers, audio URL generation |
 | `persona.js` | Persona sidebar + editor modal (CRUD) |
 | `chatrooms.js` | Chat room dropdown, room filtering, room editor, room switching with history load |
-| `settings.js` | Settings modal (LLM/TTS/STT config) |
+| `settings.js` | Servers modal (LLM/TTS/STT config) |
+| `gen-settings.js` | General settings modal (max persona replies, name mentions) |
 | `tts.js` | TTS synthesis, audio queues, Web Audio playback, audio persistence |
 | `stt.js` | Microphone recording, STT proxy, transcript insertion, audio persistence |
 | `theme.js` | Theme toggle |
@@ -47,7 +48,9 @@ To force a re-read of all three files, call `app.config.reload_all()`.
 
 `POST /api/chat` streams SSE with typed JSON events: `start`, `token`, `done`, `error`, `complete`.
 The request body includes `chat_room` (which room to persist to) and `message_id` (frontend-generated UUID for audio association).
-The `done` event returns `message_id` (server-generated UUID for the assistant message).
+With `general.max_persona_replies` > 1, a single request streams multiple `start`/`token`/`done` cycles (one per responding persona).
+Both `start` and `done` carry `message_id` (server-generated UUID for that persona's assistant message).
+`start` carries it first **on purpose**: the frontend stamps it onto streaming TTS items at enqueue time, so the ID must be generated *before* the `start` event is emitted — moving it back after the stream reintroduces cross-turn audio misattribution.
 The frontend switches on `type` in `handleSSEEvent()` in `chat.js`.
 
 Persona selection modes: `"router"` (LLM picks, low-temp 16-token call), `"random"`, or an explicit persona name.
@@ -70,7 +73,7 @@ The `SessionManager.add_user_message()` and `add_assistant_message()` methods ta
 
 Each has its own `enabled` + `base_url` in `settings.yaml`. Use the `is_active` property (requires both enabled AND a non-empty base_url) instead of checking `enabled` alone.
 
-Both TTS and STT capture audio and persist it to the current room via `persistence.js`. TTS audio is associated with the assistant message ID from the `done` event. STT audio is associated with the user message ID generated before `sendMessage()`.
+Both TTS and STT capture audio and persist it to the current room via `persistence.js`. TTS audio is associated with the assistant message ID issued in the `start` event (stamped onto each TTS item at enqueue time — never looked up in shared state at fetch-resolution time). STT audio is associated with the user message ID generated before `sendMessage()`.
 
 ## Persona CRUD cascades
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Every message is persisted to disk automatically — no configuration toggle nee
 
 - **Location**: `chatrooms/<room_name>/history.json` + audio files alongside it.
 - **Format**: JSON with `datetime` (ISO-8601) and `messages` array. Each message has `id` (UUID), `sender` ("USER" or persona name), `text`, and `audio` (array of filenames).
-- **Audio files**: Named `<message_uuid>_<index>.<ext>` (e.g. `d4ee3044_1.wav`). Extension derived from MIME type, falls back to `.bin`.
+**Audio files**: Named `<message_uuid>_<index>.<ext>` (e.g. `d4ee3044_1.wav`). Extension derived from MIME type, falls back to `.bin`. Audio that arrives *before* the message row exists (STT recordings upload before the chat request creates the user message; streaming TTS sentences upload while the reply is still streaming) is staged as `<message_uuid>_pending_<hex8>.<ext>` and automatically attached to the message's audio list when `persist_message()` runs — the staging registry lives in `app/persistence.py` (`_pending_audio`), in-memory only, so a process restart in that window leaves the (valid) file unreferenced.
 - **Room switching**: `GET /api/session/load-room/<room_name>` loads persisted history and populates the in-memory session.
 - **New Chat**: `POST /api/session/new` clears both in-memory history and deletes all files in the room's persistence directory.
 - **Audio upload**: `POST /api/persist/audio?room=<room>` accepts base64 audio and appends it to the message's audio list.

--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ application, depending on how much VRAM you can throw at it.
   - Add "echo chamber" option to chat rooms (#51)
   - Add persona-to-persona chat with new option `max_persona_replies` (#43)
   - Fix scroll problem in Personas dialog (#58)
+  - Fix audio misattribution bug (#62)
 
 ## License
 

--- a/app/persistence.py
+++ b/app/persistence.py
@@ -6,15 +6,23 @@ written alongside it using the message UUID as filename prefix.
 
 This module is intentionally framework-agnostic so it can be called from
 routers, the session manager, or tests without pulling in FastAPI deps.
+
+Concurrency note: the audio upload endpoint is a sync route (it runs in
+FastAPI's thread pool) and the frontend fires uploads without awaiting
+them, so calls here can interleave. All access to a room's history.json
+is serialized through _HISTORY_LOCK: read-modify-write cycles stay
+atomic, and readers never observe a half-written file.
 """
 
 import base64
 import json
 import logging
 import shutil
+import threading
+import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from app.models import ChatMessage
 
@@ -23,6 +31,24 @@ logger = logging.getLogger(__name__)
 # Top-level persistence root — created lazily on first write.
 # app/persistence.py → .parent → app/ → .parent → project root
 _PERSISTENCE_ROOT = Path(__file__).resolve().parent.parent / "chatrooms"
+
+# Serializes all read-modify-write cycles on history.json (and all reads,
+# so a reader can never observe a file mid-truncate).
+_HISTORY_LOCK = threading.Lock()
+
+# Audio that arrived for a message whose row has not been persisted yet.
+# This happens by design in two flows:
+#   - STT: the browser uploads the recording BEFORE the chat request even
+#     creates the user message row.
+#   - streaming TTS: sentences are synthesized (and uploaded) while the
+#     assistant's reply is still streaming; the row only lands after the
+#     token stream finishes.
+# Keyed by (room_name, message_id) -> list of staging filenames written to
+# disk in the meantime. persist_message() drains the list for a new message
+# ID and attaches the files, so no audio is silently dropped or overwritten.
+# The staging registry is in-memory, so a process restart between the upload
+# and the row creation leaves the (valid) files on disk unreferenced.
+_pending_audio: Dict[Tuple[str, str], List[str]] = {}
 
 
 def _room_dir(room_name: str) -> Path:
@@ -51,6 +77,40 @@ def _audio_filename(message_id: str, index: int, mime_type: Optional[str] = None
     return f"{message_id}_{index}{_audio_file_extension(mime_type)}"
 
 
+def _staged_audio_filename(message_id: str, mime_type: Optional[str]) -> str:
+    """Generate a stable, unique filename for pre-row audio.
+
+    The file is written before the message row exists, so its final position
+    in the message's audio list is unknown. A stable unique name (rather than
+    a guessed index) means the name is final on first write: playback
+    buttons injected with it during the live session keep working, and
+    persist_message() simply records the same name in history.json.
+    """
+    return f"{message_id}_pending_{uuid.uuid4().hex[:8]}{_audio_file_extension(mime_type)}"
+
+
+def _read_history_file(room_name: str) -> Dict[str, Any]:
+    """Load the room's history JSON (or a fresh skeleton if none exists).
+
+    Caller must hold _HISTORY_LOCK.
+    """
+    path = _history_path(room_name)
+    if path.exists():
+        with open(path) as f:
+            return json.load(f)
+    return {"datetime": None, "messages": []}
+
+
+def _write_history_file(room_name: str, data: Dict[str, Any]) -> None:
+    """Atomically-enough write the room's history JSON.
+
+    Caller must hold _HISTORY_LOCK. The directory is expected to exist
+    (every public write path creates it first).
+    """
+    with open(_history_path(room_name), "w") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
 # ---------------------------------------------------------------------------
 # Message persistence
 # ---------------------------------------------------------------------------
@@ -58,33 +118,35 @@ def _audio_filename(message_id: str, index: int, mime_type: Optional[str] = None
 def persist_message(room_name: str, message: ChatMessage, message_id: str) -> str:
     """Append a message to the room's persisted history and write to disk.
 
+    Any audio that was uploaded for this message ID before the row existed
+    (see _pending_audio) is attached to the new row's audio list in this
+    same write.
+
     Returns the message ID (same one passed in).
     """
-    room = _room_dir(room_name)
-    room.mkdir(parents=True, exist_ok=True)
-    path = _history_path(room_name)
+    with _HISTORY_LOCK:
+        room = _room_dir(room_name)
+        room.mkdir(parents=True, exist_ok=True)
 
-    # Load existing history or start fresh
-    if path.exists():
-        with open(path) as f:
-            data: Dict[str, Any] = json.load(f)
-    else:
-        data = {"datetime": None, "messages": []}
+        data = _read_history_file(room_name)
+        data["datetime"] = datetime.now().astimezone().isoformat()
 
-    now = datetime.now().astimezone().isoformat()
-    data["datetime"] = now
+        sender = "USER" if message.role == "user" else (message.persona or "unknown")
+        entry = {
+            "id": message_id,
+            "sender": sender,
+            "text": message.content,
+            "audio": list(_pending_audio.pop((room_name, message_id), [])),
+        }
+        data["messages"].append(entry)
 
-    sender = "USER" if message.role == "user" else (message.persona or "unknown")
-    data["messages"].append({
-        "id": message_id,
-        "sender": sender,
-        "text": message.content,
-        "audio": [],
-    })
+        _write_history_file(room_name, data)
 
-    with open(path, "w") as f:
-        json.dump(data, f, indent=2, ensure_ascii=False)
-
+    if entry["audio"]:
+        logger.info(
+            "Attached %d pre-row audio file(s) to message %s in room '%s'",
+            len(entry["audio"]), message_id, room_name,
+        )
     logger.debug("Persisted message %s to room '%s'", message_id, room_name)
     return message_id
 
@@ -97,38 +159,50 @@ def persist_audio(
 ) -> str:
     """Save an audio file for a message and update its audio list in history.
 
+    If the message row does not exist yet (STT audio uploaded before the chat
+    request creates the user message, or a TTS sentence synthesized while the
+    reply is still streaming), the file is staged under a unique name and the
+    name is remembered; persist_message() attaches it when the row is created.
+    Never returns a filename that another upload can overwrite.
+
     Returns the filename that was written.
     """
-    room = _room_dir(room_name)
-    room.mkdir(parents=True, exist_ok=True)
-    path = _history_path(room_name)
+    with _HISTORY_LOCK:
+        room = _room_dir(room_name)
+        room.mkdir(parents=True, exist_ok=True)
 
-    # Single read — determine next index and locate the target message
-    data: Dict[str, Any] = {"datetime": None, "messages": []}
-    if path.exists():
-        with open(path) as f:
-            data = json.load(f)
+        data = _read_history_file(room_name)
 
-    index = 0
-    msg_found = None
-    for msg in data.get("messages", []):
-        if msg["id"] == message_id:
-            index = len(msg.get("audio", []))
-            msg_found = msg
-            break
+        index = 0
+        msg_found = None
+        for msg in data.get("messages", []):
+            if msg["id"] == message_id:
+                index = len(msg.get("audio", []))
+                msg_found = msg
+                break
 
-    filename = _audio_filename(message_id, index, mime_type)
+        raw = base64.b64decode(audio_base64)
 
-    # Write the raw audio bytes
-    raw = base64.b64decode(audio_base64)
-    with open(room / filename, "wb") as f:
-        f.write(raw)
+        if msg_found is None:
+            # Stage until the message row exists. Writing an unlinked
+            # "<id>_0.<ext>" here is how early streaming/STT uploads used to
+            # overwrite each other and vanish on reload.
+            filename = _staged_audio_filename(message_id, mime_type)
+            with open(room / filename, "wb") as f:
+                f.write(raw)
+            _pending_audio.setdefault((room_name, message_id), []).append(filename)
+            logger.warning(
+                "Audio for message %s in room '%s' arrived before the message "
+                "row was persisted; staged as '%s'",
+                message_id, room_name, filename,
+            )
+            return filename
 
-    # Update the message's audio list in a single write
-    if msg_found:
+        filename = _audio_filename(message_id, index, mime_type)
+        with open(room / filename, "wb") as f:
+            f.write(raw)
         msg_found.setdefault("audio", []).append(filename)
-    with open(path, "w") as f:
-        json.dump(data, f, indent=2, ensure_ascii=False)
+        _write_history_file(room_name, data)
 
     logger.debug("Persisted audio '%s' for message %s in room '%s'", filename, message_id, room_name)
     return filename
@@ -140,13 +214,8 @@ def load_history(room_name: str) -> List[Dict[str, Any]]:
     Returns a list of message dicts matching the JSON schema.
     Returns an empty list if no history exists.
     """
-    path = _history_path(room_name)
-    if not path.exists():
-        return []
-
-    with open(path) as f:
-        data: Dict[str, Any] = json.load(f)
-
+    with _HISTORY_LOCK:
+        data = _read_history_file(room_name)
     return data.get("messages", [])
 
 
@@ -156,13 +225,8 @@ def load_history_with_metadata(room_name: str) -> Dict[str, Any]:
     Returns a dict with "datetime" and "messages" keys.
     Returns {"datetime": None, "messages": []} if no history exists.
     """
-    path = _history_path(room_name)
-    if not path.exists():
-        return {"datetime": None, "messages": []}
-
-    with open(path) as f:
-        data: Dict[str, Any] = json.load(f)
-
+    with _HISTORY_LOCK:
+        data = _read_history_file(room_name)
     return {
         "datetime": data.get("datetime"),
         "messages": data.get("messages", []),
@@ -173,15 +237,21 @@ def clear_room(room_name: str) -> None:
     """Delete all persisted files for a room.
 
     The subdirectory itself is preserved (so it still exists for future messages).
+    Staged audio awaiting this room's message rows is dropped from the registry
+    too — the files are being deleted anyway.
     """
-    room = _room_dir(room_name)
-    if not room.exists():
-        return
+    with _HISTORY_LOCK:
+        for key in [k for k in _pending_audio if k[0] == room_name]:
+            _pending_audio.pop(key, None)
 
-    for item in room.iterdir():
-        if item.is_file():
-            item.unlink()
-        elif item.is_dir():
-            shutil.rmtree(item)
+        room = _room_dir(room_name)
+        if not room.exists():
+            return
+
+        for item in room.iterdir():
+            if item.is_file():
+                item.unlink()
+            elif item.is_dir():
+                shutil.rmtree(item)
 
     logger.info("Cleared persistence for room '%s'", room_name)

--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -190,8 +190,17 @@ async def _chat_stream(req: ChatRequest) -> AsyncIterator[str]:
 
         replied_personas.append(persona_name)
 
-        # Emit start event — include the user's message_id so frontend can track it
-        yield f'data: {json.dumps({"type": "start", "persona": persona_name, "user_message_id": user_message_id})}\n\n'
+        # Generate the assistant message ID BEFORE emitting "start". The
+        # frontend stamps it onto every TTS item enqueued during this
+        # response, so audio is associated with the correct message no
+        # matter when each fetch resolves. Generating it after the stream
+        # (and backfilling later) is how audio got misattributed across turns.
+        assistant_message_id = str(uuid.uuid4())
+
+        # Emit start event — include the user's message_id so frontend can track it,
+        # and this response's message_id so streaming TTS audio can be associated
+        # with the correct message from the first token onward.
+        yield f'data: {json.dumps({"type": "start", "persona": persona_name, "user_message_id": user_message_id, "message_id": assistant_message_id})}\n\n'
 
         if echo_enabled:
             # Echo chamber: bypass the LLM entirely and return the user's message verbatim.
@@ -213,8 +222,7 @@ async def _chat_stream(req: ChatRequest) -> AsyncIterator[str]:
                 yield f'data: {json.dumps({"type": "error", "message": str(exc)})}\n\n'
                 return
 
-        # Generate assistant message ID and persist — subsequent personas will see this in history
-        assistant_message_id = str(uuid.uuid4())
+        # Persist — subsequent personas will see this in history
         session.add_assistant_message(full_text, persona_name, assistant_message_id)
 
         yield f'data: {json.dumps({"type": "done", "persona": persona_name, "text": full_text, "message_id": assistant_message_id})}\n\n'

--- a/static/chat.js
+++ b/static/chat.js
@@ -175,11 +175,6 @@ async function sendMessage() {
 function handleSSEEvent(event) {
     switch (event.type) {
         case "start": {
-            // A new response is starting — clear any leftover message ID from
-            // the previous response so its late-arriving audio doesn't get
-            // associated with this new message.
-            currentAssistantMessageId = null;
-
             // If currentAssistantRow already has content, this is a subsequent persona
             // reply — create a fresh bubble instead of reusing the existing one.
             const existingBubble = currentAssistantRow && currentAssistantRow.querySelector(".bubble");
@@ -187,6 +182,17 @@ function handleSSEEvent(event) {
                 currentAssistantRow = createAssistantBubble(event.persona);
                 messagesEl.appendChild(currentAssistantRow);
                 scrollToBottom();
+            }
+
+            // Adopt the server-issued message ID for this response. Every TTS item
+            // enqueued from this point on carries this ID explicitly, so audio is
+            // associated with the correct message regardless of when each fetch
+            // resolves. (The old approach — clear the global here and backfill on
+            // "done" — misattributed audio across turns whenever a fetch resolved
+            // before "done", which is the normal timing in streaming mode.)
+            currentAssistantMessageId = event.message_id || null;
+            if (currentAssistantRow && event.message_id) {
+                currentAssistantRow.dataset.messageId = event.message_id;
             }
 
             // Update the bubble with the actual persona name
@@ -205,8 +211,6 @@ function handleSSEEvent(event) {
             if (ttsStreaming) {
                 currentStreamingPersona = event.persona;
                 sentenceBuffer = "";
-                // Do NOT clear streamingTTSMessageIdByPersona here — it's keyed per persona,
-                // so a new persona starting does not affect in-flight fetches for prior personas.
             }
             break;
         }
@@ -227,21 +231,8 @@ function handleSSEEvent(event) {
             break;
         }
         case "done": {
-            // Track the assistant message ID for TTS audio association.
-            if (event.message_id) {
-                currentAssistantMessageId = event.message_id;
-                // Tag the live assistant bubble with the message ID so audio
-                // buttons can be injected into the correct DOM node later.
-                if (currentAssistantRow) {
-                    currentAssistantRow.dataset.messageId = event.message_id;
-                }
-                // Backfill the ID into any still-queued streaming TTS items and
-                // record it per-persona so in-flight fetches resolve correctly.
-                backfillStreamingTTSMessageId(event.persona, event.message_id);
-                // Persist any streaming-mode audio that was buffered before the ID was known.
-                flushTtsAudioBuffer(event.persona, event.message_id);
-            }
-
+            // The message ID was already adopted on "start" and stamped onto
+            // every TTS item at enqueue time, so there is nothing to backfill.
             if (ttsEnabled && event.text) {
                 const persona = personas.find(p => p.name === event.persona);
                 if (persona && persona.tts_capable) {
@@ -269,9 +260,9 @@ function handleSSEEvent(event) {
             break;
         }
         case "complete": {
-            // Final signal — don't clear currentAssistantMessageId here.
-            // In streaming mode, async audio fetches may still be in-flight.
-            // The ID will be cleared by the next "start" event instead.
+            // Final signal — nothing to do. In-flight audio fetches already
+            // carry their own message IDs, and currentAssistantMessageId is
+            // simply overwritten by the next "start" event.
             break;
         }
     }

--- a/static/state.js
+++ b/static/state.js
@@ -46,15 +46,9 @@ let isPlayingAudioBuffer = false;
 
 // Chat persistence — track message IDs for audio association
 let pendingUserMessageId = null; // UUID generated before sending, used for STT audio
-let currentAssistantMessageId = null; // UUID from server's "done" event, used for TTS audio
+// UUID issued by the server in the "start" event; stamped onto TTS items at enqueue time
+let currentAssistantMessageId = null;
 let currentAssistantRow = null; // The active assistant bubble row (updated on each "start" event)
-// Stable TTS message ID per persona. Set by "done" for each persona.
-// Keyed by persona name so that in-flight fetches for Persona A are not
-// clobbered when Persona B's "start" event fires.
-const streamingTTSMessageIdByPersona = new Map();
-// Buffers audio fetched during streaming TTS (before message_id is known).
-// Keyed by persona name. Each value is an array of { audio_base64, mime_type }.
-const ttsAudioBufferByPersona = new Map();
 
 const THEME_STORAGE_KEY = "talkwithme_theme";
 

--- a/static/tts.js
+++ b/static/tts.js
@@ -5,9 +5,10 @@
  *  - Non-streaming: enqueue full text after LLM finishes responding.
  *  - Streaming: split response into sentences, fetch and play in a pipeline.
  *
- * Audio persistence: each TTS fetch carries its own message ID so audio
- * is always associated with the correct message, even when the global
- * currentAssistantMessageId has been cleared by a subsequent message.
+ * Audio persistence: each TTS item is stamped with its message ID at
+ * enqueue time (the ID is issued by the server in the "start" event), so
+ * audio is always associated with the correct message regardless of when
+ * the fetch resolves — no shared-state lookup at resolution time.
  */
 
 /* ==========================================================================
@@ -95,25 +96,11 @@ function accumulateForTTS(token, personaName) {
 
 /** Push a sentence into the fetch queue and kick off the fetch pipeline. */
 function enqueueStreamingTTS(personaName, text) {
-    // In streaming mode, message_id isn't known until the "done" event.
-    // Pass null here; backfillStreamingTTSMessageId() will fill it in when "done" fires.
-    ttsRequestQueue.push({ personaName, text, messageId: null });
+    // Stamp the current message ID at enqueue time. It was issued by the
+    // server in the "start" event, so it is already correct for this
+    // response — no backfilling needed when "done" arrives.
+    ttsRequestQueue.push({ personaName, text, messageId: currentAssistantMessageId });
     processTTSRequests();
-}
-
-/**
- * Called by the "done" event handler to assign the now-known message ID to
- * all still-queued (not yet fetched) streaming TTS items for this persona,
- * and to store it so any currently in-flight fetches for this persona resolve
- * correctly via the per-persona map.
- */
-function backfillStreamingTTSMessageId(personaName, messageId) {
-    streamingTTSMessageIdByPersona.set(personaName, messageId);
-    for (const item of ttsRequestQueue) {
-        if (item.personaName === personaName && item.messageId === null) {
-            item.messageId = messageId;
-        }
-    }
 }
 
 /**
@@ -172,11 +159,8 @@ async function processAudioBufferQueue() {
  * @param {string} personaName - Which persona to synthesize for.
  * @param {string} text - Text to synthesize.
  * @param {string|null} messageId - The message ID this audio belongs to.
- *   For queued streaming items this is backfilled by backfillStreamingTTSMessageId()
- *   when "done" fires. For items already dequeued (in-flight), falls back to
- *   streamingTTSMessageIdByPersona, which is keyed per persona so that a
- *   subsequent persona's "start" event never clobbers a prior persona's entry.
- *
+ *   Stamped at enqueue time from the "start" event, so it is correct
+ *   regardless of when this fetch resolves.
  */
 async function fetchTTS(personaName, text, messageId) {
     const resp = await fetch("/api/tts", {
@@ -193,25 +177,21 @@ async function fetchTTS(personaName, text, messageId) {
     const data = await resp.json();
     if (!data.audio_base64) return null;
 
-    // Use the passed messageId if available (non-streaming, or backfilled by backfillStreamingTTSMessageId).
-    // Fall back to the per-persona map for in-flight fetches whose item was already dequeued
-    // before "done" fired. Using a per-persona Map means a subsequent persona's "start" event
-    // cannot clobber the prior persona's entry.
-    const effectiveId = messageId || streamingTTSMessageIdByPersona.get(personaName) || null;
-    if (effectiveId) {
-        uploadAudio(currentChatRoom, effectiveId, data.audio_base64, "audio/wav")
+    // Persist the audio against the message it was enqueued for.
+    if (messageId) {
+        uploadAudio(currentChatRoom, messageId, data.audio_base64, "audio/wav")
             .then(result => {
                 if (result && result.filename) {
                     // Inject a playback button into the live chat bubble
-                    addAudioButtonToAssistantMessage(effectiveId, result.filename);
+                    addAudioButtonToAssistantMessage(messageId, result.filename);
                 }
             })
             .catch(err => console.warn("Failed to persist TTS audio:", err));
     } else {
-        // Safety net: if somehow no ID is available yet, buffer by persona for later flush.
-        const buf = ttsAudioBufferByPersona.get(personaName) || [];
-        buf.push({ audio_base64: data.audio_base64, mime_type: "audio/wav" });
-        ttsAudioBufferByPersona.set(personaName, buf);
+        // Should not happen with the current protocol (the "start" event
+        // always carries a message_id). Warn loudly so a server/frontend
+        // version mismatch is visible instead of silently dropping audio.
+        console.warn("fetchTTS: no message ID available; audio will play but not be persisted");
     }
 
     // Decode base64 to ArrayBuffer for playback
@@ -239,25 +219,3 @@ function playAudio(buffer) {
     });
 }
 
-/**
- * Persist any audio buffered for a persona during streaming TTS.
- *
- * During streaming, TTS sentences are fetched as tokens arrive, but the
- * assistant's message_id isn't known until the "done" event. This function
- * flushes the buffer for the given persona once the ID is available.
- */
-function flushTtsAudioBuffer(personaName, messageId) {
-    if (!messageId || !personaName) return;
-    const buf = ttsAudioBufferByPersona.get(personaName);
-    if (!buf || buf.length === 0) return;
-    for (const entry of buf) {
-        uploadAudio(currentChatRoom, messageId, entry.audio_base64, entry.mime_type)
-            .then(result => {
-                if (result && result.filename) {
-                    addAudioButtonToAssistantMessage(messageId, result.filename);
-                }
-            })
-            .catch(err => console.warn("Failed to persist buffered TTS audio:", err));
-    }
-    ttsAudioBufferByPersona.delete(personaName);
-}


### PR DESCRIPTION
This PR addresses issue #62 by fixing a bug related to streaming audio responses from multiple personas when `max_replies` is greater than 1 and TTS Streaming mode is being used. 

The bug looks like this:

1. `start` fires → map still holds  idA1  from turn 1
2. Sentence 1 is enqueued with  messageId: null 
3. TTS fetch starts; LLM is still streaming
4. Fetch resolves →  effectiveId = null || idA1  → audio persisted to turn 1's message ✓ (wrong)

The fix is to travel the id with the work, instead of looking it up in shared state at resolution time.