### PR TITLE
Issue #61 - wire up max_turns and rename to max_turns_for_context

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ stt:
 general:
   persona_name_mentions: true
   max_persona_replies: 1
+  max_turns_for_context: 6
 ```
 
 Note that TTS and STT are both optional! You can mark them as disabled
@@ -330,6 +331,7 @@ application, depending on how much VRAM you can throw at it.
   - Add persona-to-persona chat with new option `max_persona_replies` (#43)
   - Fix scroll problem in Personas dialog (#58)
   - Fix audio misattribution bug (#62)
+  - Expose `max_turns_for_context` in config, and wire it up properly (#61)
 
 ## License
 

--- a/app/config.py
+++ b/app/config.py
@@ -70,7 +70,7 @@ class GeneralConfig(BaseModel):
     """Application-wide feature flags and preferences."""
     persona_name_mentions: bool = True
     max_persona_replies: int = Field(default=1, ge=1, le=4)
-    max_turns_for_context: int = Field(default=6, ge=1, description="Max history turns sent to the LLM")
+    max_turns_for_context: int = Field(default=6, ge=1, le=50, description="Max history turns sent to the LLM")
 
 
 class AppSettings(BaseModel):

--- a/app/config.py
+++ b/app/config.py
@@ -70,6 +70,7 @@ class GeneralConfig(BaseModel):
     """Application-wide feature flags and preferences."""
     persona_name_mentions: bool = True
     max_persona_replies: int = Field(default=1, ge=1, le=4)
+    max_turns_for_context: int = Field(default=6, ge=1, description="Max history turns sent to the LLM")
 
 
 class AppSettings(BaseModel):

--- a/app/models.py
+++ b/app/models.py
@@ -195,7 +195,7 @@ class GeneralSettingsRequest(BaseModel):
     """General configuration from the settings editor."""
     persona_name_mentions: bool = True
     max_persona_replies: int = Field(default=1, ge=1, le=4)
-    max_turns_for_context: int = Field(default=6, ge=1)
+    max_turns_for_context: int = Field(default=6, ge=1, le=50)
 
 
 class SettingsUpdateRequest(BaseModel):

--- a/app/models.py
+++ b/app/models.py
@@ -195,6 +195,7 @@ class GeneralSettingsRequest(BaseModel):
     """General configuration from the settings editor."""
     persona_name_mentions: bool = True
     max_persona_replies: int = Field(default=1, ge=1, le=4)
+    max_turns_for_context: int = Field(default=6, ge=1)
 
 
 class SettingsUpdateRequest(BaseModel):
@@ -235,6 +236,7 @@ class GeneralSettingsResponse(BaseModel):
     """General configuration for the frontend."""
     persona_name_mentions: bool
     max_persona_replies: int
+    max_turns_for_context: int
 
 
 class SettingsResponse(BaseModel):

--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -70,7 +70,8 @@ def _build_router_prompt(user_message: str, chat_room: str) -> list[dict]:
     )
 
     # Include last N conversation turns for context
-    recent = session.history[-6:] if len(session.history) >= 6 else session.history
+    max_context = get_settings().general.max_turns_for_context
+    recent = session.history[-max_context:]
     context_lines = []
     for msg in recent:
         if msg.role == "user":
@@ -211,6 +212,7 @@ async def _chat_stream(req: ChatRequest) -> AsyncIterator[str]:
             messages = session.build_llm_messages(
                 system_prompt=persona.system_prompt,
                 responding_persona=persona_name,
+                max_turns_for_context=settings.general.max_turns_for_context,
             )
             full_text = ""
             try:

--- a/app/routers/settings.py
+++ b/app/routers/settings.py
@@ -45,6 +45,7 @@ def _to_response(cfg: AppSettings) -> SettingsResponse:
         general=GeneralSettingsResponse(
             persona_name_mentions=cfg.general.persona_name_mentions,
             max_persona_replies=cfg.general.max_persona_replies,
+            max_turns_for_context=cfg.general.max_turns_for_context,
         ),
     )
 
@@ -91,6 +92,7 @@ def update_settings(req: SettingsUpdateRequest):
         general=GeneralConfig(
             persona_name_mentions=req.general.persona_name_mentions,
             max_persona_replies=req.general.max_persona_replies,
+            max_turns_for_context=req.general.max_turns_for_context,
         ),
     )
 

--- a/app/session.py
+++ b/app/session.py
@@ -99,7 +99,7 @@ class SessionManager:
         self,
         system_prompt: str,
         responding_persona: str,
-        max_turns: Optional[int] = None,
+        max_turns_for_context: Optional[int] = None,
     ) -> List[Dict[str, str]]:
         """Build the messages list for an LLM call.
 
@@ -108,15 +108,15 @@ class SessionManager:
             * User messages keep role "user".
             * This persona's messages keep role "assistant".
             * Other personas' messages become "user" with prefix "[Name]: <text>".
-        - Optionally limited to the last *max_turns* history entries.
+        - Optionally limited to the last *max_turns_for_context* history entries.
         """
         messages: List[Dict[str, str]] = [
             {"role": "system", "content": system_prompt}
         ]
 
         history_slice = self._history
-        if max_turns is not None:
-            history_slice = self._history[-max_turns:]
+        if max_turns_for_context is not None:
+            history_slice = self._history[-max_turns_for_context:]
 
         for msg in history_slice:
             if msg.role == "user":

--- a/settings.yaml
+++ b/settings.yaml
@@ -18,3 +18,4 @@ stt:
 general:
   persona_name_mentions: true
   max_persona_replies: 1
+  max_turns_for_context: 6

--- a/static/gen-settings.js
+++ b/static/gen-settings.js
@@ -51,6 +51,7 @@ async function loadGenSettingsIntoForm() {
         const data = await resp.json();
         gsfMaxPersonaReplies.value = data.general.max_persona_replies ?? 1;
         gsfPersonaNameMentions.checked = data.general.persona_name_mentions ?? true;
+        gsfMaxTurnsForContext.value = data.general.max_turns_for_context ?? 6;
         return true;
     } catch (err) {
         console.error("Failed to load settings:", err);
@@ -77,6 +78,11 @@ async function submitGenSettings(e) {
         return showGenSettingsError("Max Persona Replies must be between 1 and 4.");
     }
 
+    const maxTurns = parseInt(gsfMaxTurnsForContext.value, 10);
+    if (isNaN(maxTurns) || maxTurns < 1 || maxTurns > 50) {
+        return showGenSettingsError("Max Turns for Context must be between 1 and 50.");
+    }
+
     // Fetch current full settings so we can patch only the general section
     let current;
     try {
@@ -95,6 +101,7 @@ async function submitGenSettings(e) {
         general: {
             persona_name_mentions: gsfPersonaNameMentions.checked,
             max_persona_replies: maxReplies,
+            max_turns_for_context: maxTurns,
         },
     };
 

--- a/static/state.js
+++ b/static/state.js
@@ -145,3 +145,4 @@ const genSettingsForm = document.getElementById("gen-settings-form");
 const genSettingsError = document.getElementById("gen-settings-error");
 const gsfMaxPersonaReplies = document.getElementById("gsf-max-persona-replies");
 const gsfPersonaNameMentions = document.getElementById("gsf-persona-name-mentions");
+const gsfMaxTurnsForContext = document.getElementById("gsf-max-turns-for-context");

--- a/templates/index.html
+++ b/templates/index.html
@@ -371,6 +371,10 @@
                                 <span>Auto-select persona on name mention</span>
                             </label>
                         </div>
+                        <div class="form-row">
+                            <label for="gsf-max-turns-for-context">Max Turns for Context <span class="field-hint">(1–50)</span></label>
+                            <input id="gsf-max-turns-for-context" type="number" min="1" max="50" required>
+                        </div>
                     </fieldset>
                 </div>
                 <div class="form-actions">


### PR DESCRIPTION
This PR addresses #61 by properly wiring up `max_turns` and renaming it to make its intended purpose more clear. There should be no lingering references to `max_turns`, and the property should now be exposed both in `settings.yaml` (in the general section) and also in the Settings dialog. The user can use this property to control context growth during large conversations, by pruning out older messages when communicating with the LLM.