### PR TITLE
Issue #49 - use UTF-8 for history file, and make writes atomic

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ application, depending on how much VRAM you can throw at it.
   - Fix scroll problem in Personas dialog (#58)
   - Fix audio misattribution bug (#62)
   - Expose `max_turns_for_context` in config, and wire it up properly (#61)
+  - Force UTF-8 for history file writing, and make it atomic (#49)
 
 ## License
 

--- a/app/persistence.py
+++ b/app/persistence.py
@@ -16,6 +16,7 @@ atomic, and readers never observe a half-written file.
 
 import base64
 import json
+import locale
 import logging
 import os
 import shutil
@@ -93,13 +94,34 @@ def _staged_audio_filename(message_id: str, mime_type: Optional[str]) -> str:
 def _read_history_file(room_name: str) -> Dict[str, Any]:
     """Load the room's history JSON (or a fresh skeleton if none exists).
 
-    Caller must hold _HISTORY_LOCK.
+    Tries UTF-8 first. If that fails with a UnicodeDecodeError (e.g. a file
+    written on Windows under cp1252 before the encoding fix), falls back to
+    the system's preferred encoding, then immediately rewrites the file in
+    UTF-8 so the migration is a one-shot operation.
+
+    Caller must hold _HISTORY_LOCK (required for the migration re-write).
     """
     path = _history_path(room_name)
-    if path.exists():
+    if not path.exists():
+        return {"datetime": None, "messages": []}
+
+    try:
         with open(path, encoding="utf-8") as f:
             return json.load(f)
-    return {"datetime": None, "messages": []}
+    except UnicodeDecodeError:
+        # File was likely written in the system's legacy encoding (e.g. cp1252
+        # on Windows). Read it with that encoding, then rewrite in UTF-8 so
+        # future loads don't hit this path again.
+        fallback_encoding = locale.getpreferredencoding(False)
+        logger.warning(
+            "history.json for room '%s' is not valid UTF-8; migrating from "
+            "%s to UTF-8 on first read",
+            room_name, fallback_encoding,
+        )
+        with open(path, encoding=fallback_encoding) as f:
+            data = json.load(f)
+        _write_history_file(room_name, data)
+        return data
 
 
 def _write_history_file(room_name: str, data: Dict[str, Any]) -> None:

--- a/app/persistence.py
+++ b/app/persistence.py
@@ -17,6 +17,7 @@ atomic, and readers never observe a half-written file.
 import base64
 import json
 import logging
+import os
 import shutil
 import threading
 import uuid
@@ -96,19 +97,32 @@ def _read_history_file(room_name: str) -> Dict[str, Any]:
     """
     path = _history_path(room_name)
     if path.exists():
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             return json.load(f)
     return {"datetime": None, "messages": []}
 
 
 def _write_history_file(room_name: str, data: Dict[str, Any]) -> None:
-    """Atomically-enough write the room's history JSON.
+    """Atomically write the room's history JSON.
+
+    Writes to a temporary file in the same directory, then swaps it into
+    place with os.replace(). This way readers never observe a
+    half-truncated file, even if the process dies mid-write.
 
     Caller must hold _HISTORY_LOCK. The directory is expected to exist
     (every public write path creates it first).
     """
-    with open(_history_path(room_name), "w") as f:
-        json.dump(data, f, indent=2, ensure_ascii=False)
+    target = _history_path(room_name)
+    # The temp file must live on the same filesystem for os.replace() to be atomic.
+    tmp_path = target.with_suffix(".tmp")
+    try:
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+        os.replace(tmp_path, target)
+    except BaseException:
+        # Don't leave a half-written .tmp lying around if anything fails.
+        tmp_path.unlink(missing_ok=True)
+        raise
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This PR addresses issue #49 by forcing UTF-8 for the `history.json` file, regardless of the system codepage. This avoids problems with emoji characters on Windows systems. This PR also switches to an atomic write operation for this file, so that errors when writing the file don't result in a half-written corrupted file.