### PR TITLE
Issue #66 - fix chat room sorting in UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ application, depending on how much VRAM you can throw at it.
   - Save generated audio and allow replay (#5)
   - Add screenshots and better setup guidance to README (#17)
   - Add read-only "server type" field in TTS server settings (Qwen3-TTS or dots.tts) (#36)
-- **2026-08-15** v4.0
+- **2026-08-16** v4.0
   - Relax chat room name restrictions to allow spaces (#45)
   - Rename `language` to `reference_audio_language` in persona config (#46)
   - Avoid Jinja2 version 3.1.5 as a mitigation for #50
@@ -333,6 +333,7 @@ application, depending on how much VRAM you can throw at it.
   - Fix audio misattribution bug (#62)
   - Expose `max_turns_for_context` in config, and wire it up properly (#61)
   - Force UTF-8 for history file writing, and make it atomic (#49)
+  - Fix chatroom sorting in UI (#66)
 
 ## License
 

--- a/static/chatrooms.js
+++ b/static/chatrooms.js
@@ -107,7 +107,13 @@ function applyChatRoomFilter() {
  */
 function renderChatRoomDropdown() {
     chatRoomDropdown.innerHTML = "";
-    for (const room of allChatRooms) {
+    // "default" (All Personas) always first; remainder sorted alphabetically, case-insensitive
+    const sorted = [...allChatRooms].sort((a, b) => {
+        if (a.name === "default") return -1;
+        if (b.name === "default") return 1;
+        return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+    });
+    for (const room of sorted) {
         const opt = document.createElement("option");
         opt.value = room.name;
         opt.textContent = room.name === "default" ? "All Personas" : room.name;
@@ -275,8 +281,10 @@ function closeChatRoomsEditor() {
 function renderChatRoomList() {
     crListEl.innerHTML = "";
 
-    // Only show non-default rooms
-    const rooms = allChatRooms.filter(r => r.name !== "default");
+    // Only show non-default rooms, sorted alphabetically (case-insensitive)
+    const rooms = allChatRooms
+        .filter(r => r.name !== "default")
+        .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }));
 
     if (rooms.length === 0) {
         crListEl.innerHTML = '<p class="cr-empty">No chat rooms yet. Click &ldquo;+ New Room&rdquo; to create one.</p>';


### PR DESCRIPTION
This PR addresses issue #66 by fixing a minor sorting bug for chat rooms in both the chat room dropdown in the left panel, and also in the chat room edit modal. The default chat room is always listed first, followed by all user-defined chat rooms in alphabetical order. This fixes the old, broken behavior of listing them in whatever order the back end returns them (which is typically creation order).