### PR TITLE
Issue #94 - fix CSS issues in edit modals

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ details about setting up the server-side TTS script.
 - **Work in progress; TODO add release date when ready** v6.0
   - Minor bug fix: persona ordering was inconsistent in UI (#82)
   - Major changes to Persona persistence (#87)
+  - Fix longstanding display issues in Persona/Chat Room modals (#94)
 
 ## License
 

--- a/static/style.css
+++ b/static/style.css
@@ -82,6 +82,17 @@ html, body {
     overflow: hidden;
 }
 
+/*
+ * Generic show/hide utility. JS toggles the "hidden" class on modal
+ * overlays, error banners, and the list/form views inside the persona and
+ * chat room editors. The !important is load-bearing, not decoration:
+ * #pe-list-view and #pe-form-view set their layout via ID selectors, and
+ * an ID rule would out-specify a plain .hidden rule and defeat it.
+ */
+.hidden {
+    display: none !important;
+}
+
 /* --------------------------------------------------------------------------
    Top bar
    -------------------------------------------------------------------------- */
@@ -226,10 +237,6 @@ html, body {
     border-color: var(--accent);
     border-style: solid;
     color: #fff;
-}
-
-.btn-add-persona.hidden {
-    display: none;
 }
 
 /* Remove persona "x" button on persona cards */
@@ -701,10 +708,6 @@ html, body {
     padding: 20px;
 }
 
-.modal-overlay.hidden {
-    display: none;
-}
-
 .modal-box {
     background: var(--bg-secondary);
     border: 1px solid var(--border-color);
@@ -1065,10 +1068,6 @@ html, body {
     padding: 8px 14px;
     font-size: 0.85rem;
     margin: 0 20px 0 20px;
-}
-
-.pe-form-error.hidden {
-    display: none;
 }
 
 .pe-confirm-msg {


### PR DESCRIPTION
This PR addresses issue #94 by adding a missing CSS `.hidden` rule that was causing problems throughout the front end, most notably in the Persona modal and the Chat Room modal. Manual testing looks MUCH better now.
